### PR TITLE
basic memory mapping/paging

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/rendering.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/paging.c
 )
 
 set_target_properties(kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)

--- a/kernel/include/paging.h
+++ b/kernel/include/paging.h
@@ -1,0 +1,56 @@
+//https://wiki.osdev.org/Paging         x86 2 layer paging
+//https://os.phil-opp.com/page-tables/  x64 4 layer paging
+//P4 P3 P2 P1 represent the different pagetable layers
+
+
+//uefi pagetables are placed in a nonreadable section by default
+
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define PAGETABLE_SIZE 0x100000
+
+//temporary solution before memory allocation is done
+extern uint64_t page_zone_stack[PAGETABLE_SIZE];
+extern uint64_t* page_zone_pointer;
+
+#define PAGING_PRESENT    (1L << 0)
+#define PAGING_WRITABLE   (1L << 1)
+#define PAGING_USERSPACE  (1L << 2)
+
+#define PAGING_WRITETHROUGH (1L << 3)
+#define PAGING_NOCACHE      (1L << 4)
+#define PAGING_ACCESSED     (1L << 5)
+#define PAGING_DIRTY        (1L << 6)
+
+#define PAGING_LARGE        (1L << 7)
+#define PAGING_GLOBAL       (1L << 8)
+#define PAGING_DIR_NONEXEC  (1L << 63)
+
+#define PAGING_PTRMASK ((1L << 48) - (1L << 12))    //bits 48 - 12
+
+//FLAGS TO BE APPLIED WHEN ALLOCATING NEW PAGETABLES
+#define PAGETABLE_DEFAULT (PAGING_PRESENT | PAGING_WRITABLE)
+
+//returns the P4 pointer
+uint64_t* get_cr3();
+
+//sets the P4 pointer
+void set_cr3(uint64_t* P4);
+
+
+//maps all virtual adidresses between virtaddr_low and virtaddr_high relatve to phys_low and makes sure they're in the pagetable
+//
+//ex:
+//map_pages(P4, 0x4000, 0x8000, 0x0000, PAGETABLE_DEFAULT)
+//will map all virtual addresses 0x4000 - 0x8000 to 0x0000 - 0x4000 using the flags in PAGETABLE_DEFAULT
+void map_pages(uint64_t* table, uint64_t virtaddr_low, uint64_t virtaddr_high, uint64_t phys_low, uint64_t flags);
+
+//identity maps any address between virtaddr_low and virtaddr_high and makes sure they're in the pagetable
+//all pages will have PAGETABLE_DEFAULT set 
+void identity_map_pages(uint64_t* table, uint64_t virtaddr_low, uint64_t virtaddr_high, uint64_t flags);
+
+//gets a pointer to the pagetable entry that maps virtaddr to physical space
+//returns 0 if virtaddr is unpaged
+uint64_t* fetch_page(uint64_t* table, uint64_t virtaddr);

--- a/kernel/src/paging.c
+++ b/kernel/src/paging.c
@@ -1,0 +1,166 @@
+#include "paging.h"
+
+#define create_table_entry(addr) \
+    (((uint64_t)addr & PAGING_PTRMASK) | PAGETABLE_DEFAULT | PAGING_PRESENT)
+
+uint64_t* get_cr3() {
+    uint64_t* ptr;
+    asm("mov %%cr3, %0" : "=r"(ptr));
+
+    return ptr;
+}
+
+void set_cr3(uint64_t* P4) {
+    asm("mov %0, %%cr3"
+        : // no outputs
+        : "r"(P4));
+}
+
+uint64_t page_zone_stack[PAGETABLE_SIZE] __attribute__((aligned(4096)));
+uint64_t* page_zone_pointer = &page_zone_stack[0];
+
+/*
+    TEMPORARY PAGE ALLOCATION
+
+    When heap allocation is implemented, we can actively check if pagetable contains similar
+   children. If a pagetable can be remade as a single large page then all children will be freed and
+   should be available for new page tables.
+*/
+uint64_t* alloc_pagetable() { return page_zone_pointer += 512; }
+
+// correctly indexed list containing the masks for each page table layer
+const uint64_t pagingmasks[5] = {
+    (1L << 12) - (1L << 0),  // Offset
+    (1L << 21) - (1L << 12), // P1: bits (21 - 12]
+    (1L << 30) - (1L << 21), // P2: bits (30 - 21]
+    (1L << 39) - (1L << 30), // P3: bits (39 - 30]
+    (1L << 48) - (1L << 39)  // P4: bits (48 - 39]
+};
+
+// gets the table layer P's index of an address
+uint64_t get_table(uint64_t physaddr, uint8_t P) {
+    return (physaddr & pagingmasks[P]) >> (3 + 9 * P);
+}
+
+// splits a large page into a pagetable
+// depth is the paging layer of the table entry
+// returns the corrected pagetable entry
+uint64_t subdivide_large_table(uint64_t table_entry, uint64_t depth) {
+    const bool large = table_entry & PAGING_LARGE;
+    if (!large) return table_entry;
+
+    uint64_t current_addr = table_entry & PAGING_PTRMASK;
+    uint64_t* new_addr = alloc_pagetable();
+    uint64_t flags = (table_entry & ~PAGING_PTRMASK);
+
+    // P1 entries can't be large
+    if (depth > 2) flags &= ~PAGING_LARGE;
+
+    uint64_t delta = 1UL << (3 + 9 * depth);
+
+    for (int i = 0; i < 512; i++) {
+        // apply flags and update address in new page table
+        new_addr[i] = current_addr + i * delta + PAGETABLE_DEFAULT;
+    }
+
+    return create_table_entry(new_addr);
+}
+
+// allocates a new table if needed and returns the entry pointing said table
+uint64_t alloc_missing_table(uint64_t table_entry) {
+    if (table_entry & PAGING_PRESENT) {
+        return table_entry;
+    }
+
+    return create_table_entry(alloc_pagetable());
+}
+
+typedef struct {
+    uint64_t virtaddr_low;
+    uint64_t virtaddr_high;
+    uint64_t physoffset;
+    uint64_t flags;
+} MapParams;
+
+// recursive helper function for map_pages
+void rec_setpage(uint64_t* table, uint64_t tableaddr, uint8_t depth, MapParams* params) {
+    // align table address with virutal address
+    // this is the same as finding the lower bound of a table
+    if (tableaddr < params->virtaddr_low) {
+        tableaddr += params->virtaddr_low & pagingmasks[depth];
+    }
+
+    uint64_t delta = 1L << (3 + 9 * depth);
+
+    // go through all relevant tables
+    int low = get_table(tableaddr, depth);
+    while (low < 512 && tableaddr <= params->virtaddr_high) {
+        const uint64_t physaddr = tableaddr + params->physoffset;
+
+        const bool filled_page = (tableaddr + delta) <= params->virtaddr_high;
+        const bool is_large = table[low] & PAGING_LARGE;
+        const bool is_present = table[low] & PAGING_PRESENT;
+        const bool P1 = depth <= 1, P2 = depth == 2;
+
+        uint64_t applied_flags = params->flags & ~PAGING_PTRMASK;
+
+        // set_value maps pagetable adresses and goes to the next iteration
+        if (P1) goto set_value;
+
+        if (P2 && filled_page) {
+            if (is_large || !is_present) goto set_value;
+
+            // already subdivided
+            rec_setpage((uint64_t*)(table[low] & PAGING_PTRMASK), tableaddr, depth - 1, params);
+            goto next;
+        }
+
+        // table entry must be split into subsegments
+        table[low] = alloc_missing_table(table[low]);
+        table[low] = subdivide_large_table(table[low], depth);
+
+        rec_setpage((uint64_t*)(table[low] & PAGING_PTRMASK), tableaddr, depth - 1, params);
+        goto next;
+
+    set_value:
+
+        if (!P1) applied_flags |= PAGING_LARGE;
+
+        table[low] = (physaddr & PAGING_PTRMASK) | applied_flags;
+
+    next:
+        // incremenet current page
+        tableaddr += delta;
+        low++;
+    }
+}
+
+void map_pages(uint64_t* table, uint64_t low, uint64_t high, uint64_t phys_low, uint64_t flags) {
+    MapParams params = {
+        low & PAGING_PTRMASK, high & PAGING_PTRMASK, (phys_low - low) & PAGING_PTRMASK, flags};
+
+    rec_setpage(table, 0, 4, &params);
+}
+
+void identity_map_pages(uint64_t* table, uint64_t low, uint64_t high, uint64_t flags) {
+    map_pages(table, low, high, low, flags);
+}
+
+uint64_t* fetch_page(uint64_t* table, uint64_t virtaddr) {
+    for (int i = 4; i > 0; --i) {
+        // get relative table address
+        const int P = get_table(virtaddr, i);
+        const bool large = table[P] & PAGING_LARGE;
+
+        // return when a page is reached
+        if (i == 1 || large) return &table[P];
+
+        // check for missing page
+        const bool present = table[P] & PAGING_PRESENT;
+        if (!present) return 0;
+
+        table = (uint64_t*)(table[P] & PAGING_PTRMASK);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Adds easy access to the cr3 register.
paging_fetch retrieves the lowest level page of a virtual address.
```
uint64_t* P4 = get_cr3();
uint64_t* page = paging_fetch(P4, P4);

if (*page & f_paging_writable) {
    put_string("uefi pagetables are writable", 10, 10);
}else {
    put_string("big fuck, we're forced to make our own", 10, 10);
}
```

turns out uefi default settings don't give us writing access to their pagetables.
we can create our own pagetable with the paging_map_identity function:

```
uint64_t* P4 = page_zone_stack;
uint64_t sz = 0x2000000UL * 0x0080;

paging_map_identity(P4, 0, sz);
set_cr3(P4);

put_string("frame buffer is identitymapped", 10, 16);
```
there is also a paging_map function which alters maps a range of virtual addresses to a range of physical addresses.
An example can be seen in the comment before the function declaration in paging.h

Also note that the gotos in rec_setpage are highly justified since they make the code simpler and doesn't mess with control flow or reading order.