### PR TITLE
Setup IDT and enable interrupts

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/rendering.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/gdt.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/idt.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/paging.c
 )
 

--- a/kernel/include/idt.h
+++ b/kernel/include/idt.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <stdint.h>
+
+#define INTERRUPT_GATE 14
+#define TRAP_GATE 15
+
+/* This is used when creating interrupt handlers using GCCs __atrribute__((interrupt))
+
+   Example:
+
+   __attribute__((interrupt)) void irq_handler(InterruptFrame* frame) {
+       // Do stuff
+   }
+ */
+typedef struct {
+    uint64_t rip;
+    uint64_t cs;
+    uint64_t flags;
+    uint64_t rsp;
+    uint64_t ss;
+} __attribute__((packed)) InterruptFrame;
+
+void setup_idt();
+
+void register_interrupt(uint8_t irq, uint8_t type, uint64_t handler_address);
+

--- a/kernel/src/idt.c
+++ b/kernel/src/idt.c
@@ -1,0 +1,56 @@
+#include "idt.h"
+#include "gdt.h"
+
+#include <stdint.h>
+
+// https://wiki.osdev.org/Interrupt_Descriptor_Table#IDT_in_IA-32e_Mode_.2864-bit_IDT.29
+typedef struct {
+    uint16_t offset_0_15;
+    uint16_t selector;
+    uint8_t ist;
+    uint8_t type_attr;
+    uint16_t offset_16_31;
+    uint32_t offset_32_63;
+    uint32_t reserved;
+} __attribute__((packed)) IDTEntry;
+
+// IDT should be 8-byte aligned:
+// https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf#G11.25354
+IDTEntry __attribute__((aligned(8))) g_idt[256] = {0};
+
+void setup_idt() {
+    struct {
+        uint16_t size;
+        uint64_t base;
+    } __attribute__((packed)) idt = {.size = sizeof(g_idt) - 1, .base = (uint64_t)&g_idt};
+
+    asm(
+        // Set IDT
+        "lidt (%[idt])\n"
+        // Enable interrupts
+        "sti\n"
+        : // No output
+          // Input
+        : [idt] "r"(&idt));
+}
+
+// General way to register an interrupt where you can set all values
+// This is not in the header because it doesn't make sense to specify an
+// IST, segment selector or the privilege level
+void set_idt_gate(uint8_t irq, uint8_t type, uint64_t handler_address, uint16_t segment_selector,
+                  uint8_t ist, uint8_t privilege) {
+    g_idt[irq].offset_0_15 = handler_address & 0xffff;
+    g_idt[irq].selector = segment_selector;
+    g_idt[irq].ist = ist;
+    g_idt[irq].type_attr = 0b10000000 | ((privilege & 0b11) << 6) | type;
+    g_idt[irq].offset_16_31 = (handler_address >> 16) & 0xffff;
+    g_idt[irq].offset_32_63 = (handler_address >> 32) & 0xffffffff;
+}
+
+// Convenience function to register interrupts for the kernel without an ist
+// TODO (Anton Lilja, 30-03-2021):
+// This might be a temporary interface to register interrupts,
+// we need the specify ist for certain interrupts where a new stack is needed.
+void register_interrupt(uint8_t irq, uint8_t type, uint64_t handler_address) {
+    set_idt_gate(irq, type, handler_address, GDT_KERNEL_CODE_SEGMENT, 0, 0);
+}

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include "rendering.h"
 #include "gdt.h"
+#include "idt.h"
 
 typedef struct {
     uint64_t buffer_size;
@@ -26,6 +27,11 @@ _Noreturn void kernel_entry(MemoryMap* mm, Framebuffer* fb) {
     setup_gdt_and_tss();
 
     put_string("Global descriptor table initalized", 10, 10);
+
+    // Interrupts are enabled here.
+    // They can be registered using the register_interrupt(...) function
+    setup_idt();
+    put_string("Interrupt descriptor table initalized", 10, 11);
 
     // This function can't return
     while (1)


### PR DESCRIPTION
Closes #1 

This pull request adds the functions:
- ```setup_idt``` which sets a new IDT and enables interrupts
- ```register_interrupt``` which lets you register an interrupt for an IRQ

It also adds the struct ```InterruptFrame``` which is used when using ```__attribute__(interrupt)``` when creating interrupt handlers.

#### Resources:
- [OSDev IDT](https://wiki.osdev.org/Interrupt_Descriptor_Table)
- [Intel manual (Section on interrupts)](https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf)
- [Task state segment](https://wiki.osdev.org/Task_State_Segment)