### PR TITLE
pagetable creation/management

### DIFF
--- a/kernel/include/paging.h
+++ b/kernel/include/paging.h
@@ -39,27 +39,23 @@ typedef uint64_t PageFlags;
 typedef uint64_t PageEntry;
 
 
-//temporary solution before memory allocation is done
-extern uint64_t page_zone_stack[PAGETABLE_SIZE];
-extern uint64_t* page_zone_pointer;
+#define GET_PAGE_FLAGS(page_entry) ((page_entry) & ~PAGING_PTRMASK)
+#define GET_PAGE_ADDRESS(page_entry) ((page_entry) & PAGING_PTRMASK)
 
-#define GET_PAGE_FLAGS(page_entry) (page_entry & ~PAGING_PTRMASK)
-#define GET_PAGE_ADDRESS(page_entry) (page_entry & PAGING_PTRMASK)
+#define PAGING_PRESENT      (1UL << 0)
+#define PAGING_WRITABLE     (1UL << 1)
+#define PAGING_USERSPACE    (1UL << 2)
 
-#define PAGING_PRESENT    (1L << 0)
-#define PAGING_WRITABLE   (1L << 1)
-#define PAGING_USERSPACE  (1L << 2)
+#define PAGING_WRITETHROUGH (1UL << 3)
+#define PAGING_NOCACHE      (1UL << 4)
+#define PAGING_ACCESSED     (1UL << 5)
+#define PAGING_DIRTY        (1UL << 6)
 
-#define PAGING_WRITETHROUGH (1L << 3)
-#define PAGING_NOCACHE      (1L << 4)
-#define PAGING_ACCESSED     (1L << 5)
-#define PAGING_DIRTY        (1L << 6)
+#define PAGING_LARGE        (1UL << 7)
+#define PAGING_GLOBAL       (1UL << 8)
+#define PAGING_DIR_NONEXEC  (1UL << 63)
 
-#define PAGING_LARGE        (1L << 7)
-#define PAGING_GLOBAL       (1L << 8)
-#define PAGING_DIR_NONEXEC  (1L << 63)
-
-#define PAGING_PTRMASK ((1L << 48) - (1L << 12))    //bits 48 - 12
+#define PAGING_PTRMASK ((1UL << 48) - (1UL << 12))    //bits 48 - 12
 
 //returns the P4 pointer
 PageEntry* get_cr3();

--- a/kernel/include/paging.h
+++ b/kernel/include/paging.h
@@ -2,6 +2,32 @@
 //https://os.phil-opp.com/page-tables/  x64 4 layer paging
 //P4 P3 P2 P1 represent the different pagetable layers
 
+/*
+    This is currently set up to provide convenient way of creating pagetables, 
+    mapping and contstraining memory usage, which is a necessity for processes. 
+
+    Under the assumption that each process use their own pagetables, which
+    is described here:
+    
+    https://forum.osdev.org/viewtopic.php?f=1&t=32996
+    https://en.wikipedia.org/wiki/Context_switch#Cost
+
+    Then setting up a new page table could look like this:
+
+        PageEntry* new_p4 = create_pagetable();
+        map_pages(new_p4, 0, program_size, program_start, PAGING_WRITEABLE | PAGING_USERSPACE | ...);
+        map_pages(new_p4, data_start, data_end, program_start + data_start, PAGING_USERSPACE | ...);
+
+    ... go through each section and set flags ...
+
+    then when the process is swapped, you can get or set the table used by the MMU
+
+        set_cr3(new_p4);
+
+    when the process is killed, its pagetable can be freed
+    
+        free_pagetable(new_p4, 4);
+*/
 
 //uefi pagetables are placed in a nonreadable section by default
 
@@ -12,7 +38,6 @@
 typedef uint64_t PageFlags;
 typedef uint64_t PageEntry;
 
-#define PAGETABLE_SIZE 0x100000
 
 //temporary solution before memory allocation is done
 extern uint64_t page_zone_stack[PAGETABLE_SIZE];
@@ -42,7 +67,7 @@ PageEntry* get_cr3();
 //sets the P4 pointer
 void set_cr3(PageEntry* P4);
 
-//maps all virtual adidresses between virtaddr_low and virtaddr_high relatve to phys_low and makes sure they're in the pagetable
+//maps all virtual addresses between virtaddr_low and virtaddr_high relatve to phys_low and makes sure they're in the pagetable
 //
 //ex:
 //map_pages(P4, 0x4000, 0x8000, 0x0000, PAGETABLE_DEFAULT)
@@ -55,3 +80,11 @@ void identity_map_pages(PageEntry* table, uint64_t virtaddr_low, uint64_t virtad
 //gets a pointer to the pagetable entry that maps virtaddr to physical space
 //returns 0 if virtaddr is unpaged
 PageEntry* fetch_page_entry(PageEntry* table, uint64_t virtaddr);
+
+// creates a new page table containing 512 entries
+// note that the same pagetable structure is used for all depths
+PageEntry* create_pagetable();
+
+// frees a pagetable of certain depth layer
+// as example, the P4 table has a depth of 4
+void free_pagetable(PageEntry* table, uint64_t depth);

--- a/kernel/src/paging.c
+++ b/kernel/src/paging.c
@@ -130,7 +130,7 @@ PageEntry alloc_missing_table(PageEntry page_entry) {
 typedef struct {
     uint64_t virtaddr_low;
     uint64_t virtaddr_high;
-    uint64_t physoffset;
+    uint64_t physaddr_low;
     PageFlags flags;
 } MapParams;
 
@@ -187,10 +187,12 @@ void rec_setpage(PageEntry* table, uint64_t table_addr, uint8_t depth, MapParams
 
     set_mapping : // maps pagetable adresses and goes to the next iteration
     {
+        const uint64_t physical_address = table_addr + params->physaddr_low - params->virtaddr_low;
+
         PageFlags applied_flags = params->flags & ~PAGING_PTRMASK;
         if (!P1) applied_flags |= PAGING_LARGE;
 
-        table[low] = create_entry(physaddr, applied_flags);
+        table[low] = create_entry(physical_address, applied_flags);
     }
 
     next: // incremenet current page
@@ -201,7 +203,7 @@ void rec_setpage(PageEntry* table, uint64_t table_addr, uint8_t depth, MapParams
 
 void map_pages(PageEntry* table, uint64_t low, uint64_t high, uint64_t phys_low, PageFlags flags) {
     MapParams params = {
-        low & PAGING_PTRMASK, high & PAGING_PTRMASK, (phys_low - low) & PAGING_PTRMASK, flags};
+        low & PAGING_PTRMASK, high & PAGING_PTRMASK, phys_low & PAGING_PTRMASK, flags};
 
     rec_setpage(table, 0, 4, &params);
 }

--- a/kernel/src/paging.c
+++ b/kernel/src/paging.c
@@ -18,17 +18,59 @@ void set_cr3(PageEntry* P4) {
         : "r"(P4));
 }
 
-PageEntry page_zone_stack[PAGETABLE_SIZE] __attribute__((aligned(4096)));
-PageEntry* page_zone_pointer = &page_zone_stack[0];
+#define PAGETABLES_BUFFERSIZE 0xFA000
 
-/*
-    TEMPORARY PAGE ALLOCATION
+// this is where all pagetables are stored, we don't want to run out.
+PageEntry g_page_tables[PAGETABLES_BUFFERSIZE] __attribute__((aligned(4096)));
+PageEntry* g_page_tables_top = &g_page_tables[0];
 
-    When heap allocation is implemented, we can actively check if pagetable contains similar
-   children. If a pagetable can be remade as a single large page then all children will be freed and
-   should be available for new page tables.
-*/
-PageEntry* alloc_pagetable() { return page_zone_pointer += 512; }
+// hopefully, less than a quarter of the page stack should only be free at once
+#define FREED_TABLE_SIZE (PAGETABLES_BUFFERSIZE / 512 / 4)
+PageEntry* g_free_tables_stack[FREED_TABLE_SIZE];
+uint64_t g_free_tables_count;
+
+// leaks occur if too many tables are freed in total, this will count how many are leaked.
+// can be used for diagnostics later on.
+uint64_t g_leaked_tables = 0;
+
+PageEntry* create_pagetable() {
+    if (g_free_tables_count > 0) {
+        PageEntry* table = g_free_tables_stack[g_free_tables_count];
+
+        // clear contents of freed table
+        // REPLACE WITH MEMZERO WHEN AVALIABLE
+        for (int i = 0; i < 512; i++) table[i] = 0UL;
+
+        g_free_tables_count--;
+        return table;
+    }
+
+    return g_page_tables_top += 512;
+}
+
+void free_pagetable(PageEntry* table, uint64_t depth) {
+    // go through children of high level tables
+    if (depth > 2) {
+        for (int i = 0; i < 512; i++) {
+            const bool is_present = table[i] & PAGING_PRESENT;
+            const bool is_large = table[i] & PAGING_LARGE;
+
+            if (!is_present || is_large) continue;
+
+            PageEntry* child = GET_TABLE_PTR(table[i]);
+            free_pagetable(child, depth - 1);
+        }
+    }
+
+    if (g_free_tables_count >= FREED_TABLE_SIZE) {
+        g_leaked_tables++;
+
+        return;
+    }
+
+    g_free_tables_stack[g_free_tables_count] = table;
+    g_free_tables_count++;
+}
 
 // correctly indexed list containing the masks for each page table layer
 const PageFlags pagingmasks[5] = {
@@ -44,11 +86,11 @@ PageEntry create_entry(uint64_t address, PageFlags flags) {
 }
 
 // gets the table layer P's index of an address
-uint64_t get_table(uint64_t virtaddr, uint8_t P) {
+uint64_t get_table_index(uint64_t virtaddr, uint8_t P) {
     return (virtaddr & pagingmasks[P]) >> (3 + 9 * P);
 }
 
-// splits a large page into a pagetable
+// splits a large page into a pagetable.
 // depth is the paging layer of the table entry
 // returns the corrected pagetable entry
 PageEntry subdivide_large_table(PageEntry page_entry, uint64_t depth) {
@@ -57,7 +99,7 @@ PageEntry subdivide_large_table(PageEntry page_entry, uint64_t depth) {
 
     uint64_t table_addr = GET_PAGE_ADDRESS(page_entry);
 
-    PageEntry* new_table = alloc_pagetable();
+    PageEntry* new_table = create_pagetable();
     uint64_t new_addr = (uint64_t)new_table;
 
     PageFlags flags = GET_PAGE_FLAGS(page_entry);
@@ -65,7 +107,7 @@ PageEntry subdivide_large_table(PageEntry page_entry, uint64_t depth) {
     // P1 entries can't be large
     if (depth > 2) flags &= ~PAGING_LARGE;
 
-    uint64_t delta = 1UL << (3 + 9 * depth);
+    uint64_t delta = GET_LAYER_PAGESIZE(depth);
 
     // apply flags and update address in new page table
     for (int i = 0; i < 512; i++) {
@@ -80,7 +122,7 @@ PageEntry alloc_missing_table(PageEntry page_entry) {
     const bool is_present = page_entry & PAGING_PRESENT;
     if (is_present) return page_entry;
 
-    const uint64_t alloc_addr = (uint64_t)alloc_pagetable();
+    const uint64_t alloc_addr = (uint64_t)create_pagetable();
     return create_entry(alloc_addr, PAGETABLE_DEFAULT);
 }
 
@@ -99,14 +141,16 @@ void rec_setpage(PageEntry* table, uint64_t table_addr, uint8_t depth, MapParams
         table_addr += params->virtaddr_low & pagingmasks[depth];
     }
 
-    uint64_t delta = 1L << (3 + 9 * depth);
+    uint64_t delta = GET_LAYER_PAGESIZE(depth);
 
     // go through all relevant page entries
-    int low = get_table(table_addr, depth);
+    int low = get_table_index(table_addr, depth);
     while (low < 512 && table_addr <= params->virtaddr_high) {
-        const uint64_t physaddr = table_addr + params->physoffset;
 
-        const bool filled_page = (table_addr + delta) <= params->virtaddr_high;
+        // determines if all pagetable entries are covered.
+        const bool filled_page =
+            table_addr >= params->virtaddr_low && table_addr + delta <= params->virtaddr_high;
+
         const bool is_large = table[low] & PAGING_LARGE;
         const bool is_present = table[low] & PAGING_PRESENT;
         const bool P1 = depth <= 1, P2 = depth == 2;
@@ -117,7 +161,9 @@ void rec_setpage(PageEntry* table, uint64_t table_addr, uint8_t depth, MapParams
             if (is_large || !is_present) goto set_mapping;
 
             // entry points to an already subdivided table
-            goto iterate_table;
+            // since all children will be mapped the same and share the same flags,
+            // it's instead freed and remade into a large page
+            goto collect_table_pages;
         }
 
         // table entry must be split into subsegments
@@ -130,6 +176,12 @@ void rec_setpage(PageEntry* table, uint64_t table_addr, uint8_t depth, MapParams
         rec_setpage(next_table, table_addr, depth - 1, params);
 
         goto next;
+    }
+
+    collect_table_pages : // frees a pagetable and turns it into a large page
+    {
+        PageEntry* next_table = GET_TABLE_PTR(table[low]);
+        free_pagetable(next_table, depth);
     }
 
     set_mapping : // maps pagetable adresses and goes to the next iteration
@@ -160,7 +212,7 @@ void identity_map_pages(PageEntry* table, uint64_t low, uint64_t high, PageFlags
 PageEntry* fetch_page_entry(PageEntry* table, uint64_t virtaddr) {
     for (int i = 4; i > 0; --i) {
         // get relative table address
-        const int P = get_table(virtaddr, i);
+        const int P = get_table_index(virtaddr, i);
         const bool is_large = table[P] & PAGING_LARGE;
 
         // return when a page is reached

--- a/kernel/src/paging.c
+++ b/kernel/src/paging.c
@@ -3,7 +3,8 @@
 // FLAGS TO BE APPLIED WHEN ALLOCATING NEW PAGETABLES
 #define PAGETABLE_DEFAULT (PAGING_PRESENT | PAGING_WRITABLE)
 
-#define GET_TABLE_PTR(page_entry) (PageEntry*)(page_entry & PAGING_PTRMASK)
+#define GET_TABLE_PTR(page_entry) (PageEntry*)((page_entry)&PAGING_PTRMASK)
+#define GET_LAYER_PAGESIZE(depth) (1UL << (3 + 9 * (depth)))
 
 PageEntry* get_cr3() {
     uint64_t* ptr;


### PR DESCRIPTION

Paging is new set up to provide convenient way of creating pagetables, 
mapping and contstraining memory usage, which is a necessity for processes. 
Paging, as in swapping pages between disk and RAM will come later. 

Under the assumption that each process use their own pagetables, which
is described here:

https://forum.osdev.org/viewtopic.php?f=1&t=32996
https://en.wikipedia.org/wiki/Context_switch#Cost

Then setting up a new page table could look like this:

    PageEntry* new_p4 = create_pagetable();
    map_pages(new_p4, 0, program_size, program_start, PAGING_WRITEABLE | PAGING_USERSPACE | ...);
    map_pages(new_p4, data_start, data_end, program_start + data_start, PAGING_USERSPACE | ...);

... go through each section and set flags ...

then when the process is swapped, you can get or set the table used by the MMU

    set_cr3(new_p4);

when the process is killed, its pagetable can be freed

    free_pagetable(new_p4, 4);
