### PR TITLE
set up PIC for hardware interrupts

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/paging.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/port_io.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pci.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/pic.c
 )
 
 set_target_properties(kernel PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld)

--- a/kernel/include/pic.h
+++ b/kernel/include/pic.h
@@ -1,0 +1,29 @@
+// Programmable Interrupt Controller
+// https://wiki.osdev.org/PIC
+#include <stdint.h>
+
+#define PIC1		    0x20
+#define PIC2		    0xA0
+
+#define PIC1_COMMAND	PIC1
+#define PIC1_DATA	(PIC1+1)
+#define PIC2_COMMAND	PIC2
+#define PIC2_DATA	(PIC2+1)
+
+
+// will initialize PIC and slave to interrupts 0x20 to 0x30
+// https://wiki.osdev.org/Interrupts#General_IBM-PC_Compatible_Interrupt_Information
+void setup_interrupt_requests();
+
+// sends an end of interrupt (EOI) to the used PIC(s)
+// irq_line is 0x20 lower than the IDT index
+// as example, the keyboard interrupt has IDT index 0x21 and therefore irq_line = 0x01
+void send_end_of_interrupt(uint8_t irq_line);
+
+// enables request handler irq_line by removing it from the correct PIC's mask
+// irq_line is 0x20 lower than the interrupts IDT index
+void enable_interrupt_request(uint8_t irq_line);
+
+// disables request handler irq_line by adding it to the correct PIC's mask
+// irq_line is 0x20 lower than the interrupts IDT index
+void disable_interrupt_request(uint8_t irq_line);

--- a/kernel/src/idt.c
+++ b/kernel/src/idt.c
@@ -1,5 +1,6 @@
 #include "idt.h"
 #include "gdt.h"
+#include "pic.h"
 
 #include <stdint.h>
 
@@ -24,6 +25,9 @@ void setup_idt() {
         uint64_t base;
     } __attribute__((packed)) idt = {.size = sizeof(g_idt) - 1, .base = (uint64_t)&g_idt};
 
+    // initialize controllers for hardware interrupts
+    setup_interrupt_requests();
+
     asm(
         // Set IDT
         "lidt (%[idt])\n"
@@ -31,7 +35,7 @@ void setup_idt() {
         "sti\n"
         : // No output
           // Input
-        : [idt] "r"(&idt));
+        : [ idt ] "r"(&idt));
 }
 
 // General way to register an interrupt where you can set all values

--- a/kernel/src/pic.c
+++ b/kernel/src/pic.c
@@ -1,0 +1,56 @@
+#include "pic.h"
+#include "port_io.h"
+
+void setup_interrupt_requests() {
+    // init with icw4
+    port_out_u8(PIC1_COMMAND, 0x11);
+    port_out_u8(PIC2_COMMAND, 0x11);
+
+    // remap offsets to 0x20 - 0x30
+    port_out_u8(PIC1_DATA, 0x20);
+    port_out_u8(PIC2_DATA, 0x28);
+
+    // cascade slave
+    port_out_u8(PIC1_DATA, 0x04);
+    port_out_u8(PIC2_DATA, 0x02);
+
+    // ICW4 x8086 mode
+    port_out_u8(PIC1_DATA, 0x01);
+    port_out_u8(PIC2_DATA, 0x01);
+    // end of initialization sequence
+
+    // mask all interrupts
+    port_out_u8(PIC1_DATA, 0xff);
+    port_out_u8(PIC2_DATA, 0xff);
+}
+
+void send_end_of_interrupt(uint8_t irq_line) {
+    // 0x20 is an EOI command.
+    if (irq_line > 8) port_out_u8(PIC2_COMMAND, 0x20);
+
+    port_out_u8(PIC1_COMMAND, 0x20);
+}
+
+void enable_interrupt_request(uint8_t irq_line) {
+    uint16_t channel = PIC1_DATA;
+    if (irq_line > 8) {
+        channel = PIC2_DATA;
+        irq_line -= 8;
+    }
+
+    // each PIC has a 1 bit flag for each request
+    const uint8_t mask = port_in_u8(channel);
+    port_out_u8(channel, mask & ~(1 << irq_line));
+}
+
+void disable_interrupt_request(uint8_t irq_line) {
+    uint16_t channel = PIC1_DATA;
+    if (irq_line > 8) {
+        channel = PIC2_DATA;
+        irq_line -= 8;
+    }
+
+    // each PIC has a 1 bit flag for each request
+    const uint8_t mask = port_in_u8(channel);
+    port_out_u8(channel, mask | (1 << irq_line));
+}


### PR DESCRIPTION
After some discussion, it's apparent that we shouldn't use any PIC code for the meantime. And instead use a properly setup APIC when needed.


closes #30 

https://wiki.osdev.org/8259_PIC

This commit initializes the PICs before loading the IDT, and disables all
hardware interrupts.

To hook one of the PIC interrupt requests, ie 0x01 for the keyboard. You
will have to first register it to the IDT as IRQ (0x20 + 0x01), then enable
interrupt request 0x01 using `enable_interrupt_request(0x01)`.

Within the handler, it's also neccessary to tell the corresponding PIC
that the interrupt has been processed. This is done by calling the
`send_end_of_interrupt(uint8_t irq_line)` function, where irq_line = 0x01
for the keyboard.