### PR TITLE
Add KERNEL_ASSERT macro

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,6 +20,6 @@
 ```
 mkdir build
 cd build
-cmake .. -DUEFI_FIRMWARE=<path to OVMF.fd> -DQEMU_ARGS=<any extra qemu args>
+cmake .. -DUEFI_FIRMWARE=<path to OVMF.fd> -DQEMU_ARGS=<any extra qemu args> -DENABLE_KERNEL_ASSERTS=<ON or OFF>
 make run
 ```

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(ENABLE_KERNEL_ASSERTS "Enables asserts in the kernel" ON)
+
 add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/rendering.c
@@ -33,5 +35,11 @@ target_link_options(kernel PRIVATE
   -nostdlib
   -T ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld
 )
+
+if(ENABLE_KERNEL_ASSERTS)
+  target_compile_definitions(kernel PRIVATE
+    ENABLE_KERNEL_ASSERTS
+  )
+endif()
 
 target_compile_features(kernel PRIVATE c_std_11)

--- a/kernel/include/kassert.h
+++ b/kernel/include/kassert.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifdef ENABLE_KERNEL_ASSERTS
+#    include "rendering.h"
+#    define KERNEL_ASSERT(CONDITION, STR) \
+        if (!(CONDITION)) {               \
+            [[unlikely]] clear_screen(0); \
+            g_fg_color = 0xff0000;        \
+            put_string(STR, 0, 0);        \
+            while (1)                     \
+                ;                         \
+        }
+
+#else
+#    define KERNEL_ASSERT(CONDITION, STR)
+#endif


### PR DESCRIPTION
The macro checks if the condition is met otherwise it clears the screen,
prints the message in red and halts the processor.

This can be used to check for unrecoverable errors

This PR also adds an option in CMake to globally disable all asserts.