### PR TITLE
Replace symbol lookup in bootloader with staged kernel entry (Finding the stack).

### DIFF
--- a/bootloader/include/elf-loader.h
+++ b/bootloader/include/elf-loader.h
@@ -2,4 +2,4 @@
 #include <efi.h>
 
 EFI_STATUS load_kernel(EFI_SYSTEM_TABLE* st, EFI_FILE* root, CHAR16* filename,
-                       EFI_PHYSICAL_ADDRESS* entry_point, EFI_PHYSICAL_ADDRESS* stack);
+                       EFI_PHYSICAL_ADDRESS* entry_point);

--- a/bootloader/src/elf-loader.c
+++ b/bootloader/src/elf-loader.c
@@ -1,7 +1,6 @@
 #include "elf-loader.h"
 
 #include <efi.h>
-#include <stdbool.h>
 
 #define EI_NIDENT 16
 
@@ -16,15 +15,8 @@
 #define EI_DATA 5
 
 #define PT_LOAD 1
-#define PT_DYNAMIC 2
 
 #define PF_X 1
-
-#define DT_NULL 0
-#define DT_HASH 4
-#define DT_STRTAB 5
-#define DT_SYMTAB 6
-#define DT_GNU_HASH 0x6ffffef5
 
 typedef struct {
     unsigned char e_ident[EI_NIDENT];
@@ -54,38 +46,8 @@ typedef struct {
     UINT64 p_align;
 } __attribute__((packed)) Elf64_Phdr;
 
-typedef struct {
-    INT64 d_tag;
-    UINT64 d_val_or_addr;
-} __attribute__((packed)) Elf64_Dyn;
-
-typedef struct {
-    UINT32 st_name;
-    UINT8 st_info;
-    UINT8 st_other;
-    UINT16 st_shndx;
-    UINT64 st_value;
-    UINT64 st_size;
-} __attribute__((packed)) Elf64_Sym;
-
-UINT32 gnu_hash(const char* name) {
-    UINT32 hash = 5381;
-    for (; *name; name++) {
-        hash = (hash << 5) + hash + *name;
-    }
-    return hash;
-}
-
-INT32 strcmp(const char* a, const char* b) {
-    while (*a && (*a == *b)) {
-        ++a;
-        ++b;
-    }
-    return (*(UINT8*)a) - (*(UINT8*)b);
-}
-
 EFI_STATUS load_kernel(EFI_SYSTEM_TABLE* st, EFI_FILE* root, CHAR16* filename,
-                       EFI_PHYSICAL_ADDRESS* entry_point, EFI_PHYSICAL_ADDRESS* stack) {
+                       EFI_PHYSICAL_ADDRESS* entry_point) {
     EFI_STATUS status;
 
     // Open kernel elf file
@@ -139,8 +101,7 @@ EFI_STATUS load_kernel(EFI_SYSTEM_TABLE* st, EFI_FILE* root, CHAR16* filename,
     status = file->Read(file, &len, (void*)program_headers);
     if (EFI_ERROR(status)) return status;
 
-    // Read PT_LOAD and PT_DYNAMIC segments into memory
-    Elf64_Dyn* dynamic_table = NULL;
+    // Read PT_LOAD segments into memory
     UINTN loaded_segments = 0;
     for (UINTN p = 0; p < file_header->e_phnum; ++p) {
         Elf64_Phdr* header = &program_headers[p];
@@ -173,111 +134,12 @@ EFI_STATUS load_kernel(EFI_SYSTEM_TABLE* st, EFI_FILE* root, CHAR16* filename,
                                      0);
             ++loaded_segments;
         }
-        // Load dynamic table
-        else if (header->p_type == PT_DYNAMIC) {
-            // Set file position to the offset
-            status = file->SetPosition(file, header->p_offset);
-            if (EFI_ERROR(status)) return status;
-
-            // Allocate memory for dynamic table
-            status = st->BootServices->AllocatePool(
-                EfiLoaderData, header->p_memsz, (void**)&dynamic_table);
-            if (EFI_ERROR(status)) return status;
-
-            // Read dynamic table into memory
-            len = header->p_memsz;
-            status = file->Read(file, &len, (void*)dynamic_table);
-            if (EFI_ERROR(status)) return status;
-        }
     }
 
     // If no segments were loaded then there was no executable code
     if (loaded_segments == 0) return EFI_NOT_FOUND;
 
-    // No dynamic table exists
-    if (dynamic_table == NULL) return EFI_NOT_FOUND;
-
-    // Get address to the top of stack from the symbol table
-    {
-        *stack = 0;
-        UINT32* hashtab = NULL;
-        char* strtab = NULL;
-        Elf64_Sym* symtab = NULL;
-        bool hash_is_gnu = false;
-
-        // Loop over dynamic table
-        for (int i = 0; dynamic_table[i].d_tag != DT_NULL; ++i) {
-            switch (dynamic_table[i].d_tag) {
-                case DT_STRTAB: {
-                    strtab = (char*)dynamic_table[i].d_val_or_addr;
-                    break;
-                }
-                case DT_SYMTAB: {
-                    symtab = (Elf64_Sym*)dynamic_table[i].d_val_or_addr;
-                    break;
-                }
-                case DT_GNU_HASH: {
-                    hashtab = (UINT32*)dynamic_table[i].d_val_or_addr;
-                    hash_is_gnu = true;
-                    break;
-                }
-                case DT_HASH: {
-                    if (!hash_is_gnu) hashtab = (UINT32*)dynamic_table[i].d_val_or_addr;
-                    break;
-                }
-            }
-        }
-
-        if (strtab == NULL || symtab == NULL || hashtab == NULL) return EFI_NOT_FOUND;
-
-        // There are two types of hash tables used by ELF binaries.
-        if (hash_is_gnu) {
-            const UINT32 bucket_count = hashtab[0];
-            const UINT32 symbol_offset = hashtab[1];
-            const UINT32 bloom_size = hashtab[2];
-            const UINT32 bloom_shift = hashtab[3];
-            const UINT64* bloom_filter = (UINT64*)&hashtab[4];
-            const UINT32* buckets = (UINT32*)&bloom_filter[bloom_size];
-            const UINT32* chain = &buckets[bucket_count];
-
-            const UINT32 hash = gnu_hash("__stack_top__");
-
-            const UINT64 word = bloom_filter[(hash / 64) % bloom_size];
-            const UINT64 mask = (UINT64)1 << (hash % 64) | (UINT64)1
-                                                               << ((hash >> bloom_shift) % 64);
-
-            // Stack was not found
-            if ((word & mask) != mask) return EFI_NOT_FOUND;
-
-            UINT32 symbol_index = buckets[hash % bucket_count];
-            if (symbol_index < symbol_offset) return EFI_NOT_FOUND;
-
-            while (true) {
-                const char* symbol_name = strtab + symtab[symbol_index].st_name;
-                const UINT32 symbol_hash = chain[symbol_index - symbol_offset];
-
-                if ((hash | 1) == (symbol_hash | 1) && strcmp(symbol_name, "__stack_top__") == 0) {
-                    *stack = (EFI_PHYSICAL_ADDRESS)symtab[symbol_index].st_value;
-                    break;
-                }
-
-                if (symbol_hash & 1) break;
-
-                ++symbol_index;
-            }
-        }
-        else {
-            // TODO (Anton Lilja, 26-03-2021): Implement standard ELF hash table lookup
-            return EFI_UNSUPPORTED;
-        }
-    }
-
-    // No stack was found
-    if (*stack == 0) return EFI_NOT_FOUND;
-
-    // Free file header, program headers, and dynamic table
-    status = st->BootServices->FreePool(dynamic_table);
-    if (EFI_ERROR(status)) return status;
+    // Free file header and program headers
     status = st->BootServices->FreePool(program_headers);
     if (EFI_ERROR(status)) return status;
     status = st->BootServices->FreePool(file_header);

--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -62,8 +62,7 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
 
     // Load kernel ELF image, get entry point and stack addresses
     EFI_PHYSICAL_ADDRESS kernel_entry;
-    EFI_PHYSICAL_ADDRESS stack;
-    status = load_kernel(st, root, L"KERNEL.ELF", &kernel_entry, &stack);
+    status = load_kernel(st, root, L"KERNEL.ELF", &kernel_entry);
     if (EFI_ERROR(status)) return status;
 
     // Close file system
@@ -123,9 +122,6 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
     if (EFI_ERROR(status)) return status;
 
     asm volatile(
-        // Setup stack and base pointer
-        "mov %[stack], %%rsp\n"
-        "mov %[stack], %%rbp\n"
         // Set up arguments in correct registers
         "mov %[memory_map], %%rdi\n"
         "mov %[frame_buffer], %%rsi\n"
@@ -134,7 +130,6 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
         : // No output
           // Input
         : [kernel_entry] "r"(kernel_entry),
-          [stack] "r"(stack),
           [memory_map] "r"(&memory_map),
           [frame_buffer] "r"(&frame_buffer)
         // Clobbers

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,6 +1,7 @@
 option(ENABLE_KERNEL_ASSERTS "Enables asserts in the kernel" ON)
 
 add_executable(kernel
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/stage1_entry.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/rendering.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/gdt.c

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -1,4 +1,4 @@
-ENTRY (kernel_entry)
+ENTRY (stage1_kernel_entry)
 
 SECTIONS
 {

--- a/kernel/src/stage1_entry.c
+++ b/kernel/src/stage1_entry.c
@@ -1,0 +1,17 @@
+extern char __stack_top__;
+extern char kernel_entry;
+
+__attribute__((naked)) void stage1_kernel_entry() {
+    asm(
+        // Setup stack and base pointer
+        "mov %[stack], %%rsp\n"
+        "mov %[stack], %%rbp\n"
+
+        // Jump to the real kernel entry
+        "jmp *%[kernel_entry]\n"
+        : // No output
+          // Input
+        : [stack] "r"(&__stack_top__), [kernel_entry] "r"(&kernel_entry)
+        // Clobbers
+        : "rsp", "rbp");
+}


### PR DESCRIPTION
By doing a staged kernel entry we can remove the need for loading the dynamic table and doing a hash table lookup (symbol table).

The bootloader jumps to stage1_kernel_entry which then loads the stack and base pointer before jumping to the real kernel entry.

Closes #15 because it no longer be needed