### PR TITLE
Read kernel into allocated pages (Bug fix)

### DIFF
--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -122,7 +122,15 @@ void setup_gdt_and_tss() {
     struct {
         uint16_t size;
         uint64_t base;
-    } __attribute__((packed)) gdt = {.size = sizeof(g_gdt) - 1, .base = (uint64_t)&g_gdt};
+    } __attribute__((packed)) gdt;
+
+    // TODO(Anton Lilja, 10-04-21):
+    // We have to do manual assignment here because the compiler might try to optimize in virtual
+    // address pointers at compile time otherwise.
+    // Find way to disable this optimization or
+    // make sure to map kernel correctly before any of this code.
+    gdt.size = sizeof(g_gdt);
+    gdt.base = (uint64_t)&g_gdt;
 
     set_gdt_and_tss((void*)&gdt);
 }

--- a/kernel/src/idt.c
+++ b/kernel/src/idt.c
@@ -22,7 +22,15 @@ void setup_idt() {
     struct {
         uint16_t size;
         uint64_t base;
-    } __attribute__((packed)) idt = {.size = sizeof(g_idt) - 1, .base = (uint64_t)&g_idt};
+    } __attribute__((packed)) idt;
+
+    // TODO(Anton Lilja, 10-04-21):
+    // We have to do manual assignment here because the compiler might try to optimize in virtual
+    // address pointers at compile time otherwise.
+    // Find way to disable this optimization or
+    // make sure to map kernel correctly before any of this code.
+    idt.size = sizeof(g_idt);
+    idt.base = (uint64_t)&g_idt;
 
     asm(
         // Set IDT


### PR DESCRIPTION
The kernel only accidentally worked before this point. We were accidentally loading the kernel into the virtual address specified by the ELF file instead of the pages we allocated.

This was fixed by making one call to AllocatePages with the total size of the kernel and then manually loading the segemnts into the correct offset.

Additional changes had to be made to gdt.c and idt.c because the compiler was
optimizing in the virtuall address in the ELF file instead of taking the acutall runtime address.