### PR TITLE
Find RSDP and pass it to Kernel

### DIFF
--- a/bootloader/CMakeLists.txt
+++ b/bootloader/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(bootloader
   ${CMAKE_CURRENT_SOURCE_DIR}/src/main.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/elf-loader.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/rsdp-finder.c
 )
 
 target_include_directories(bootloader PRIVATE 

--- a/bootloader/include/rsdp-finder.h
+++ b/bootloader/include/rsdp-finder.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <efi.h>
+
+EFI_STATUS find_rsdp(EFI_SYSTEM_TABLE* st, EFI_PHYSICAL_ADDRESS* rsdp);

--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -1,6 +1,7 @@
 #include <efi.h>
 
 #include "elf-loader.h"
+#include "rsdp-finder.h"
 
 EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
     EFI_STATUS status;
@@ -69,6 +70,12 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
     status = root->Close(root);
     if (EFI_ERROR(status)) return status;
 
+    // Find Root System Description Pointer
+    EFI_PHYSICAL_ADDRESS rsdp_addr;
+
+    status = find_rsdp(st, &rsdp_addr);
+    if (EFI_ERROR(status)) return status;
+
     // Get the memory map
     struct {
         UINT64 nbytes;
@@ -125,6 +132,7 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
         // Set up arguments in correct registers
         "mov %[memory_map], %%rdi\n"
         "mov %[frame_buffer], %%rsi\n"
+        "mov %[rsdp_addr], %%rdx\n"
 
         // Push code segment and kernel entry addres onto stack and do a long return
         "movw %%cs, %%ax\n"
@@ -133,11 +141,12 @@ EFI_STATUS efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE* st) {
         "lretq\n"
         : // No output
           // Input
-        : [kernel_entry] "r"(kernel_entry),
-          [memory_map] "r"(&memory_map),
-          [frame_buffer] "r"(&frame_buffer)
+        : [ kernel_entry ] "r"(kernel_entry),
+          [ memory_map ] "r"(&memory_map),
+          [ frame_buffer ] "r"(&frame_buffer),
+          [ rsdp_addr ] "r"(rsdp_addr)
         // Clobbers
-        : "rax", "rdi", "rsi");
+        : "rax", "rdi", "rsi", "rdx");
 
     // This point will never be reached
     return EFI_LOAD_ERROR;

--- a/bootloader/src/rsdp-finder.c
+++ b/bootloader/src/rsdp-finder.c
@@ -1,0 +1,32 @@
+#include "rsdp-finder.h"
+
+// I could not find any functions comparing two EFI_GUIDs.
+
+// Macro of GUID must be put in memory for comparisons
+const EFI_GUID acpi_guid_bytes = ACPI_20_TABLE_GUID;
+const uint8_t* acpi_guid = (uint8_t*)&acpi_guid_bytes;
+
+EFI_STATUS find_rsdp(EFI_SYSTEM_TABLE* st, EFI_PHYSICAL_ADDRESS* rsdp) {
+
+    // Iterate config table
+    for (UINTN i = 0; i < st->NumberOfTableEntries; i++) {
+        EFI_CONFIGURATION_TABLE* table = st->ConfigurationTable + i;
+
+        const uint8_t* guid = (uint8_t*)&table->VendorGuid;
+
+        { // Memcmp
+            int j = 0;
+            while (j < 16 && guid[j] == acpi_guid[j]) j++;
+
+            // If entire guid matched
+            if (j == 16) {
+                *rsdp = (EFI_PHYSICAL_ADDRESS)table->VendorTable;
+
+                return EFI_SUCCESS;
+            }
+        }
+    }
+
+    // No rsdp could be found for ACPI 2.0
+    return EFI_NOT_FOUND;
+}

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <string.h>
 
-_Noreturn void kernel_entry(void* mm, void* fb) {
+_Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
     // set frame buffer
     memcpy((void*)&g_frame_buffer, (void*)fb, sizeof(g_frame_buffer));
     clear_screen(g_bg_color);


### PR DESCRIPTION
Uses the EFI configuration table to find the RSDP2.0 pointer, which tells us where the XSDT is located. https://wiki.osdev.org/RSDP
https://wiki.osdev.org/XSDT

Note that a Version 2.0 RSDP is required for 64 bit.
Closes #29 