### PR TITLE
Make kernel run in virtual address space and remove identity mapping

### DIFF
--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
+#define FRAME_ORDERS 8
+
 typedef struct {
     void* next;
     struct {

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -11,5 +11,7 @@ VirtualAddress map_range(PhysicalAddress phys_addr, uint64_t pages);
 // Unmaps virtual address space
 void unmap(VirtualAddress virt_addr, uint64_t pages);
 
+void free_uefi_memory_and_remove_identity_mapping(void* uefi_memory_map);
+
 VirtualAddress initialize_paging(void* uefi_memory_map, PhysicalAddress kernel_phys_addr,
                                  uint64_t kernel_size);

--- a/kernel/include/rendering.h
+++ b/kernel/include/rendering.h
@@ -21,6 +21,8 @@ extern uint32_t g_bg_color;
 extern uint32_t g_fg_color;
 extern Framebuffer g_frame_buffer;
 
+void remap_framebuffer();
+
 // Color pixel at pixel coordinates
 void put_pixel(uint64_t x, uint64_t y, uint32_t color);
 

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -1,3 +1,4 @@
+#include "memory/paging.h"
 #include "rendering.h"
 #include "memory.h"
 #include "gdt.h"
@@ -66,6 +67,11 @@ _Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
     // They can be registered using the register_interrupt(...) function
     setup_idt();
     put_string("Interrupt descriptor table initalized", 10, 13);
+
+    // After this point all physical addresses have to be mapped to virtual memory
+    // NOTE: The memory pointed at by mm and fb should NOT be used after this point
+    free_uefi_memory_and_remove_identity_mapping(mm);
+    put_string("UEFI data deallocated and identity mapping removed", 10, 14);
 
     // This function can't return
     while (1)

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -55,6 +55,9 @@ _Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
     jump_to_kernel_virtual(kernel_phys_addr, kernel_virt_addr);
     put_string("Kernel now running in virtual address space", 10, 10);
 
+    remap_framebuffer();
+    put_string("Framebuffer remapped to virtual address space", 10, 11);
+
     // This disables interrupts
     setup_gdt_and_tss();
     put_string("Global descriptor table initalized", 10, 12);

--- a/kernel/src/memory/entry_pool.c
+++ b/kernel/src/memory/entry_pool.c
@@ -47,6 +47,7 @@ MemoryEntry* get_memory_entry() {
 
     MemoryEntry* entry = g_memory_entry_pool.head;
     g_memory_entry_pool.head = entry->next;
+    entry->next = 0;
     --g_memory_entry_pool.count;
     return entry;
 }

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -457,8 +457,7 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
             {
                 const PhysicalAddress addr = last->physical_start + last->num_pages * PAGE_SIZE;
                 if (addr != desc->physical_start && last != 0) {
-                    const uint64_t size = desc->physical_start -
-                                          (last->physical_start + (last->num_pages * PAGE_SIZE));
+                    const uint64_t size = desc->physical_start - addr;
 
                     KERNEL_ASSERT((addr % PAGE_SIZE) == 0, "Address not page aligned")
                     KERNEL_ASSERT((size % PAGE_SIZE) == 0, "Size not page aligned")

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -470,10 +470,7 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
             // Remove frames of specific memory types
             switch (desc->type) {
                 case EfiBootServicesCode:
-                case EfiBootServicesData:
                 case EfiRuntimeServicesCode:
-                case EfiRuntimeServicesData:
-                case EfiLoaderData:
                 case EfiConventionalMemory: break;
                 default: {
                     const bool success = remove_range(desc->physical_start, desc->num_pages);

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -9,7 +9,6 @@
 #include <string.h>
 
 #define MIN_BLOCK_SIZE PAGE_SIZE
-#define FRAME_ORDERS 8
 
 // Free list entry
 typedef struct {

--- a/kernel/src/rendering.c
+++ b/kernel/src/rendering.c
@@ -1,9 +1,22 @@
 #include "rendering.h"
 #include "font.h"
 
+#include "util.h"
+#include "memory/paging.h"
+
 Framebuffer g_frame_buffer;
 uint32_t g_bg_color = 0x00000000;
 uint32_t g_fg_color = 0xffee2a7a;
+
+void remap_framebuffer() {
+    const uint64_t framebuffer_size = round_up_to_multiple(
+        g_frame_buffer.width * g_frame_buffer.height * sizeof(uint32_t), PAGE_SIZE);
+
+    const uint64_t framebuffer_pages = framebuffer_size / PAGE_SIZE;
+
+    g_frame_buffer.address =
+        (void*)map_range((PhysicalAddress)g_frame_buffer.address, framebuffer_pages);
+}
 
 void put_pixel(uint64_t x, uint64_t y, uint32_t color) {
     // write to frame buffer, assumes 4 byte color.


### PR DESCRIPTION
* Makes the kernel run in virtual address space (also remaps stack)
* Maps the framebuffer into virtual address space
* Deallocs UEFI data.
* Removes identity mapping.