### PR TITLE
PCI-Express device enumeration and config space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,6 @@ add_custom_target(image
   VERBATIM)
 
 add_custom_target(run
-  COMMAND qemu-system-x86_64 ${QEMU_ARGS} -bios ${UEFI_FIRMWARE} -drive format=raw,file=${CMAKE_BINARY_DIR}/boot.img
+  COMMAND qemu-system-x86_64 ${QEMU_ARGS} -machine q35 -bios ${UEFI_FIRMWARE} -drive format=raw,file=${CMAKE_BINARY_DIR}/boot.img
   DEPENDS image
   VERBATIM)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/gdt.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/idt.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/port_io.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/acpi.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pci.c
 
   # Memory

--- a/kernel/include/acpi.h
+++ b/kernel/include/acpi.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct {
+    char signature[4];
+    uint32_t len;
+    uint8_t revision;
+    uint8_t checksum;
+    char OEM_ID[6];
+    char OEM_table_ID[8];
+    uint32_t OEM_revision;
+    uint32_t creator_ID;
+    uint32_t creator_revision;
+} __attribute__((packed)) ACPISDTHeader;
+
+bool find_table(const char* signature, void** table_ptr);
+
+void initialize_acpi(void* rsdp);

--- a/kernel/include/pci.h
+++ b/kernel/include/pci.h
@@ -1,47 +1,48 @@
 // https://wiki.osdev.org/PCI
 
 #pragma once
+#include "memory.h"
+
+#include <stdbool.h>
 #include <stdint.h>
 
-#define DEVICE_CLASS_MASK 0xff000000
-#define DEVICE_SUBCLASS_MASK 0xffff0000
-#define DEVICE_PROG_IF_MASK 0xffffff00
+#define PCI_DEVICE_CLASS_MASK 0xff000000
+#define PCI_DEVICE_SUBCLASS_MASK 0xffff0000
+#define PCI_DEVICE_PROG_IF_MASK 0xffffff00
+#define PCI_DEVICE_REVISION_ID_MASK 0xffffffff
 
-/*
-READ FROM CONFIG SPACE
+// PCI config space for header type 0
+typedef volatile struct {
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint16_t command;
+    uint16_t status;
+    uint8_t revision_ID;
+    uint8_t prog_IF;
+    uint8_t subclass;
+    uint8_t class_code;
+    uint8_t cache_line_size;
+    uint8_t latency_timer;
+    uint8_t header_type;
+    uint8_t BIST;
+    uint32_t BAR0;
+    uint32_t BAR1;
+    uint32_t BAR2;
+    uint32_t BAR3;
+    uint32_t BAR4;
+    uint32_t BAR5;
+    uint32_t cardbus_CIS_pointer;
+    uint16_t subsystem_vendor_id;
+    uint16_t subsystem_id;
+    uint32_t expansion_ROM_base_addr;
+    uint8_t capabilities_pointer;
+    uint8_t reserved[7];
+    uint8_t interrupt_line;
+    uint8_t interrupt_pin;
+    uint8_t min_grant;
+    uint8_t max_grant;
+} __attribute__((packed)) PCIConfigSpace0;
 
-Config data format:
-    u32:  m=|                             0 |
-    u16:  m=|             2 |             0 |
-    u8 :  m=|     3 |     2 |     1 |     0 |
-            |[32-24] [23-16]  [15-8]  [7-0] | <- bits
-    b=      |-------------------------------|
-    0x00    |Device ID      |Vendor ID      |
-    0x04    |Status         |Command        |
-    0x08    |Class  |Subcl. |Prog IF|Rev.ID |
-    0x0C    |BIST   |Head t.|Latency|CLS    |
-    ...     ...
-    0x3C    |<depends on header type>       |
+bool get_pci_device(PhysicalAddress* config_space_phys_addr, uint32_t type, uint32_t mask);
 
-    Get config data feild of device by using a read_config function with offset=(b + m)
-*/
-
-// Reads u32 of config data at offset from base_address, bit 1&0: ignored.
-uint32_t pci_read_config_u32(uint32_t base_address, uint8_t offset);
-
-// Reads u16 config data at offset from base_address, bit 1: determines which word of long that is
-// returned (1 being the highest half). bit 0: ignored.
-uint16_t pci_read_config_u16(uint32_t base_address, uint8_t offset);
-
-// Reads u8 config data at offset from base_address, bit 1&0: controlls which byte of long is
-// returned (0 being lowest and 3 baing highest).
-uint8_t pci_read_config_u8(uint32_t base_address, uint8_t offset);
-
-// Iterates trough addresses AFTER start, if (start=0) search begins at first address. If no match
-// is found return is 0. Returns base address of first device that matches target_device_type at
-// mask. Great refrence for class codes: https://wiki.osdev.org/PCI#Class_Codes.
-// Masks: DEVICE_CLASS_MASK matches Class code, DEVICE_SUBCLASS_MASK also matches Subclass, and
-// DEVICE_PROG_IF_MASK also matches Prog IF.
-// Example: to find a Floppy disk controller (ClassCode=0x01, Subclass=0x02) use
-// target_device_type=0x01020000, mask=DEVICE_SUBCLASS_MASK.
-uint32_t pci_find_next_device(uint32_t target_device_type, uint32_t mask, uint32_t start);
+void enumerate_pci_devices();

--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -1,0 +1,41 @@
+#include "acpi.h"
+
+#include "memory.h"
+
+#include <string.h>
+
+typedef struct {
+    char signature[8];
+    uint8_t checksum;
+    char OEM_ID[6];
+    uint8_t revision;
+    uint32_t rsdt_phys_addr;
+    uint32_t len;
+    PhysicalAddress xsdt_phys_addr;
+    uint8_t ext_checksum;
+    uint8_t reserved[3];
+} __attribute__((packed)) RSDP;
+
+typedef ACPISDTHeader XSDT;
+
+const XSDT* g_xsdt;
+
+bool find_table(const char* signature, void** table_ptr) {
+    const PhysicalAddress* xsdt_arr =
+        (const PhysicalAddress*)((PhysicalAddress)g_xsdt + sizeof(XSDT));
+    const uint64_t entries = (g_xsdt->len - sizeof(XSDT)) / sizeof(PhysicalAddress);
+    for (uint64_t i = 0; i < entries; ++i) {
+        const ACPISDTHeader* header = (const ACPISDTHeader*)xsdt_arr[i];
+        if (memcmp(header->signature, signature, 4) == 0) {
+            *table_ptr = (void*)header;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void initialize_acpi(void* rsdp_ptr) {
+    const RSDP* rsdp = (const RSDP*)rsdp_ptr;
+    g_xsdt = (const XSDT*)rsdp->xsdt_phys_addr;
+}

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -3,6 +3,7 @@
 #include "memory.h"
 #include "gdt.h"
 #include "idt.h"
+#include "acpi.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -68,10 +69,13 @@ _Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
     setup_idt();
     put_string("Interrupt descriptor table initalized", 10, 13);
 
+    initialize_acpi(rsdp);
+    put_string("ACPI initialized", 10, 14);
+
     // After this point all physical addresses have to be mapped to virtual memory
     // NOTE: The memory pointed at by mm and fb should NOT be used after this point
     free_uefi_memory_and_remove_identity_mapping(mm);
-    put_string("UEFI data deallocated and identity mapping removed", 10, 14);
+    put_string("UEFI data deallocated and identity mapping removed", 10, 16);
 
     // This function can't return
     while (1)

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -4,6 +4,7 @@
 #include "gdt.h"
 #include "idt.h"
 #include "acpi.h"
+#include "pci.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -71,6 +72,9 @@ _Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
 
     initialize_acpi(rsdp);
     put_string("ACPI initialized", 10, 14);
+
+    enumerate_pci_devices();
+    put_string("PCI devices enumerated", 10, 15);
 
     // After this point all physical addresses have to be mapped to virtual memory
     // NOTE: The memory pointed at by mm and fb should NOT be used after this point

--- a/kernel/src/pci.c
+++ b/kernel/src/pci.c
@@ -1,98 +1,96 @@
-#include <stdint.h>
-#include <stdbool.h>
-#include "port_io.h"
 #include "pci.h"
 
-#define PCI_REG_CONFIG_ADDRESS 0xCF8
-#define PCI_REG_CONFIG_DATA 0xCFC
+#include "kassert.h"
+#include "acpi.h"
+#include "memory/paging.h"
+#include "memory/entry_pool.h"
 
-#define VENDOR_ID_OFFSET 0x00
-#define HEADER_TYPE_OFFSET 0x0E
-// bottom offset for u32 containg Class code, Subclass, Prog IF and Revision ID
-#define DEVICE_TYPE_OFFSET 0x08
+#include <string.h>
 
-#define DEVICE_CLASS_MASK 0xff000000
-#define DEVICE_SUBCLASS_MASK 0xffff0000
-#define DEVICE_PROG_IF_MASK 0xffffff00
+typedef struct {
+    ACPISDTHeader header;
+    uint8_t reserved[8];
+} __attribute__((packed)) MCFG;
 
-#define CONFIG_ADDRESS_ZERO 0x80000000
+typedef struct {
+    PhysicalAddress base_address;
+    uint16_t segment_group;
+    uint8_t start_bus;
+    uint8_t end_bus;
+    uint8_t reserved[4];
+} __attribute__((packed)) MCFGEntry;
 
-// black-box, don't look!
-__attribute__((always_inline)) uint32_t create_config_address(uint8_t bus, uint8_t slot,
-                                                              uint8_t func, uint8_t offset) {
-    return (uint32_t)(((uint32_t)bus << 16) | ((uint32_t)(slot & 0x1F) << 11) |
-                      ((uint32_t)(func & 0x7) << 8) | ((uint32_t)offset & 0xfc) |
-                      ((uint32_t)0x80000000));
-}
+typedef struct {
+    VirtualAddress next : 48;
+    PhysicalAddress config_phys_addr : 38;
+    union {
+        struct {
+            uint8_t revision_ID;
+            uint8_t prog_IF;
+            uint8_t subclass;
+            uint8_t class_code;
+        } __attribute__((packed));
+        uint32_t type;
+    };
+    uint8_t padding;
+} __attribute__((packed)) PCIDeviceEntry;
 
-uint8_t pci_read_config_u8(uint32_t base_address, uint8_t offset) {
-    uint32_t config_address = (base_address & 0xffffff00) | (offset & ~0b11);
-    port_out_u32(PCI_REG_CONFIG_ADDRESS, config_address);
-    uint32_t config_data = port_in_u32(PCI_REG_CONFIG_DATA) >> ((offset & 0b11) * 8);
-    return (uint8_t)(config_data & 0xff);
-}
+PCIDeviceEntry* g_pci_device_list = 0;
 
-uint16_t pci_read_config_u16(uint32_t base_address, uint8_t offset) {
-    uint32_t config_address = (base_address & 0xffffff00) | (offset & ~0b11);
-    port_out_u32(PCI_REG_CONFIG_ADDRESS, config_address);
-    uint32_t config_data = port_in_u32(PCI_REG_CONFIG_DATA) >> ((offset & 0b10) * 8);
-    return (uint16_t)(config_data & 0xffff);
-}
-
-uint32_t pci_read_config_u32(uint32_t base_address, uint8_t offset) {
-    uint32_t config_address = (base_address & 0xffffff00) | (offset & ~0b11);
-    port_out_u32(PCI_REG_CONFIG_ADDRESS, config_address);
-    uint32_t config_data = port_in_u32(PCI_REG_CONFIG_DATA);
-    return config_data;
-}
-
-// uses vendor ID to check if device exists
-bool device_exists(uint32_t address) {
-    return pci_read_config_u16(address, VENDOR_ID_OFFSET) != 0xffff;
-}
-
-// returns true if device has multiple distinct functions
-bool device_is_multi_func(uint32_t address) {
-    return (pci_read_config_u8(address, HEADER_TYPE_OFFSET) & 0x80) != 0;
-}
-
-// Returns the next valid address
-uint32_t next_base_address(uint32_t last) {
-    if (last == 0) return CONFIG_ADDRESS_ZERO; // Special exception, return first address.
-    uint32_t bus = (last & 0x00ff0000) >> 16;
-    uint32_t slot = (last & 0x0000f800) >> 11;
-    uint32_t func = (last & 0x00000700) >> 8;
-
-    func++;
-    // skips to next slot if this slot's func 0 is either empty or non-multi func
-    if (func < 8 && (func > 1 || (device_exists(last) && device_is_multi_func(last)))) {
-        return create_config_address(bus, slot, func, 0);
+bool get_pci_device(PhysicalAddress* config_space_phys_addr, uint32_t type, uint32_t mask) {
+    PCIDeviceEntry* device_entry = g_pci_device_list;
+    while (device_entry != 0) {
+        if ((device_entry->type & mask) == type) {
+            *config_space_phys_addr = device_entry->config_phys_addr << 12;
+            return true;
+        }
+        device_entry = (PCIDeviceEntry*)SIGN_EXT_ADDR(device_entry->next);
     }
-
-    func = 0;
-    slot++;
-    if (slot < 32) {
-        return create_config_address(bus, slot, func, 0);
-    }
-
-    slot = 0;
-    bus++;
-    if (bus < 256) {
-        return create_config_address(bus, slot, func, 0);
-    }
-    return 0; // No remaining addresses
+    return false;
 }
 
-uint32_t pci_find_next_device(uint32_t target_device_type, uint32_t mask, uint32_t start) {
-    uint32_t address = start;
-    do {
-        address = next_base_address(address);
-        if (device_exists(address)) {
-            uint32_t device_type = pci_read_config_u32(address, DEVICE_TYPE_OFFSET);
-            if ((device_type & mask) == (target_device_type & mask)) {
-                return address;
+void enumerate_pci_devices() {
+    _Static_assert(sizeof(PCIDeviceEntry) == 16, "PCIDeviceEntry not 16 bytes");
+
+    const MCFG* mcfg = ({
+        void* table_ptr;
+        const bool success = find_table("MCFG", &table_ptr);
+        KERNEL_ASSERT(success, "MCFG could not be found")
+
+        (const MCFG*)table_ptr;
+    });
+
+    const PhysicalAddress mcfg_addr = (PhysicalAddress)mcfg;
+    const MCFGEntry* mcfg_arr = (MCFGEntry*)(mcfg_addr + sizeof(MCFG));
+    const uint64_t entries = (mcfg->header.len - sizeof(MCFG)) / sizeof(MCFGEntry);
+
+    for (uint64_t i = 0; i < entries; ++i) {
+        const PhysicalAddress base_phys_addr = mcfg_arr[i].base_address;
+        for (uint16_t bus = mcfg_arr[i].start_bus; bus < mcfg_arr[i].end_bus; ++bus) {
+            for (uint8_t device = 0; device < 32; ++device) {
+                for (uint8_t func = 0; func < 8; ++func) {
+                    const PCIConfigSpace0* config_space =
+                        (const PCIConfigSpace0*)(base_phys_addr +
+                                                 (bus << 20 | device << 15 | func << 12));
+                    const bool exists = config_space->vendor_id != 0xffff;
+
+                    const bool is_multi_func = (config_space->header_type & 0x80) != 0;
+
+                    if (func > 0 && !is_multi_func) break;
+
+                    if (!exists) continue;
+
+                    PCIDeviceEntry* device_entry = (PCIDeviceEntry*)get_memory_entry();
+                    device_entry->revision_ID = config_space->revision_ID;
+                    device_entry->prog_IF = config_space->prog_IF;
+                    device_entry->subclass = config_space->subclass;
+                    device_entry->class_code = config_space->class_code;
+                    device_entry->config_phys_addr = ((PhysicalAddress)config_space) >> 12;
+
+                    device_entry->next = (VirtualAddress)g_pci_device_list;
+                    g_pci_device_list = device_entry;
+                }
             }
         }
-    } while (address != 0);
-    return 0;
+    }
 }


### PR DESCRIPTION
* Make QEMU use the q35 machine type
* Adds a way to get ACPI tables
* Replaces the old way of getting PCI devices with the PCI-Express way. So not through port IO but memory mapped IO instead.