### PR TITLE
Acpi pci paged

### DIFF
--- a/kernel/include/acpi.h
+++ b/kernel/include/acpi.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>
+#include "memory.h"
 
 typedef struct {
     char signature[4];
@@ -14,6 +15,7 @@ typedef struct {
     uint32_t creator_revision;
 } __attribute__((packed)) ACPISDTHeader;
 
-bool find_table(const char* signature, void** table_ptr);
+void prepare_acpi_memory(void* uefi_memory_map);
+void initialize_acpi(PhysicalAddress rsdp_ptr);
 
-void initialize_acpi(void* rsdp);
+VirtualAddress get_virtual_acpi_address(PhysicalAddress physical);

--- a/kernel/include/acpi.h
+++ b/kernel/include/acpi.h
@@ -16,6 +16,8 @@ typedef struct {
 } __attribute__((packed)) ACPISDTHeader;
 
 bool sdt_is_valid(const ACPISDTHeader* sdt, char* signature);
+void* find_table(const char* signature);
+
 void prepare_acpi_memory(void* uefi_memory_map);
 void initialize_acpi(PhysicalAddress rsdp_ptr);
 

--- a/kernel/include/acpi.h
+++ b/kernel/include/acpi.h
@@ -15,6 +15,7 @@ typedef struct {
     uint32_t creator_revision;
 } __attribute__((packed)) ACPISDTHeader;
 
+bool sdt_is_valid(const ACPISDTHeader* sdt, char* signature);
 void prepare_acpi_memory(void* uefi_memory_map);
 void initialize_acpi(PhysicalAddress rsdp_ptr);
 

--- a/kernel/include/acpi.h
+++ b/kernel/include/acpi.h
@@ -4,13 +4,13 @@
 
 typedef struct {
     char signature[4];
-    uint32_t len;
+    uint32_t length;
     uint8_t revision;
     uint8_t checksum;
-    char OEM_ID[6];
-    char OEM_table_ID[8];
-    uint32_t OEM_revision;
-    uint32_t creator_ID;
+    char oem_id[6];
+    char oem_table_id[8];
+    uint32_t oem_revision;
+    uint32_t creator_id;
     uint32_t creator_revision;
 } __attribute__((packed)) ACPISDTHeader;
 

--- a/kernel/include/pci.h
+++ b/kernel/include/pci.h
@@ -43,6 +43,6 @@ typedef volatile struct {
     uint8_t max_grant;
 } __attribute__((packed)) PCIConfigSpace0;
 
-bool get_pci_device(PhysicalAddress* config_space_phys_addr, uint32_t type, uint32_t mask);
+PCIConfigSpace0* get_pci_device(uint32_t type, uint32_t mask);
 
 void enumerate_pci_devices();

--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -37,7 +37,20 @@ bool sdt_is_valid(const ACPISDTHeader* sdt, char* signature) {
 
     return !sum;
 }
+
+void* find_table(const char* signature) {
+    const uint64_t* xsdt_arr = (const uint64_t*)((VirtualAddress)g_xsdt + sizeof(XSDT));
+
+    const uint64_t entries = (g_xsdt->length - sizeof(XSDT)) / sizeof(uint64_t);
     for (uint64_t i = 0; i < entries; ++i) {
+        const ACPISDTHeader* header = (ACPISDTHeader*)get_virtual_acpi_address(xsdt_arr[i]);
+
+        if (memcmp(header->signature, signature, 4) == 0) return (void*)header;
+    }
+
+    return 0;
+}
+
 typedef struct {
     PhysicalAddress phys;
     VirtualAddress virt;

--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -1,6 +1,9 @@
 #include "acpi.h"
 
 #include "memory.h"
+#include "memory/paging.h"
+#include "memory/entry_pool.h"
+#include "uefi.h"
 
 #include <string.h>
 
@@ -25,17 +28,76 @@ bool find_table(const char* signature, void** table_ptr) {
         (const PhysicalAddress*)((PhysicalAddress)g_xsdt + sizeof(XSDT));
     const uint64_t entries = (g_xsdt->length - sizeof(XSDT)) / sizeof(PhysicalAddress);
     for (uint64_t i = 0; i < entries; ++i) {
-        const ACPISDTHeader* header = (const ACPISDTHeader*)xsdt_arr[i];
-        if (memcmp(header->signature, signature, 4) == 0) {
-            *table_ptr = (void*)header;
-            return true;
+typedef struct {
+    PhysicalAddress phys;
+    VirtualAddress virt;
+    uint64_t size;
+} ACPIMemRemap;
+
+ACPIMemRemap* g_remap_list;
+uint64_t g_remap_count;
+
+void prepare_acpi_memory(void* uefi_memory_map) {
+    UEFIMemoryMap* memory_map = (UEFIMemoryMap*)uefi_memory_map;
+
+    uint64_t entry_count = 0;
+
+    // Count pages used for ACPI
+    for (uint64_t i = 0; i < memory_map->buffer_size; i += memory_map->desc_size) {
+        UEFIMemoryDescriptor* desc = (UEFIMemoryDescriptor*)&memory_map->buffer[i];
+        if (desc->type != EfiACPIMemoryNVS && desc->type != EfiACPIReclaimMemory) continue;
+
+        entry_count += 1;
+    }
+
+    { // allocate and page remap entries
+
+        // Round up needed pages to store remap entries
+        uint64_t needed_pages = 1 + (entry_count * sizeof(ACPIMemRemap)) / PAGE_SIZE;
+
+        PageFrameAllocation* alloc = alloc_frames(needed_pages);
+        g_remap_list = (ACPIMemRemap*)map_allocation(alloc, PAGING_WRITABLE);
+
+        // dealloc pool entry
+        while (alloc != 0) {
+            void* next = alloc->next;
+            free_memory_entry((MemoryEntry*)alloc);
+
+            alloc = next;
         }
     }
 
-    return false;
+    // Store remap info
+    for (uint64_t i = 0; i < memory_map->buffer_size; i += memory_map->desc_size) {
+        UEFIMemoryDescriptor* desc = (UEFIMemoryDescriptor*)&memory_map->buffer[i];
+        if (desc->type != EfiACPIMemoryNVS && desc->type != EfiACPIReclaimMemory) continue;
+
+        const VirtualAddress virt = map_range(desc->physical_start, desc->num_pages, 0);
+        ACPIMemRemap* entry = &g_remap_list[g_remap_count++];
+
+        entry->phys = desc->physical_start;
+        entry->virt = virt;
+        entry->size = desc->num_pages * PAGE_SIZE;
+    }
 }
 
-void initialize_acpi(void* rsdp_ptr) {
-    const RSDP* rsdp = (const RSDP*)rsdp_ptr;
-    g_xsdt = (const XSDT*)rsdp->xsdt_phys_addr;
+VirtualAddress get_virtual_acpi_address(PhysicalAddress physical) {
+    for (uint64_t i = 0; i < g_remap_count; i++) {
+        ACPIMemRemap* entry = &g_remap_list[i];
+
+        // Find address in range
+        if (entry->phys < physical && entry->phys + entry->size > physical)
+            return (entry->virt - entry->phys + physical);
+        }
+
+    return 0;
+    }
+
+void initialize_acpi(PhysicalAddress rsdp_ptr) {
+    RSDP* rsdp = (RSDP*)get_virtual_acpi_address(rsdp_ptr);
+    KERNEL_ASSERT(rsdp, "RSDP VIRTUAL ADDRESS NOT FOUND");
+}
+
+    g_xsdt = (const XSDT*)get_virtual_acpi_address(rsdp->xsdt_phys_addr);
+    KERNEL_ASSERT(g_xsdt, "XSDT VIRTUAL ADDRESS NOT FOUND");
 }

--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -7,10 +7,10 @@
 typedef struct {
     char signature[8];
     uint8_t checksum;
-    char OEM_ID[6];
+    char oem_id[6];
     uint8_t revision;
     uint32_t rsdt_phys_addr;
-    uint32_t len;
+    uint32_t length;
     PhysicalAddress xsdt_phys_addr;
     uint8_t ext_checksum;
     uint8_t reserved[3];
@@ -23,7 +23,7 @@ const XSDT* g_xsdt;
 bool find_table(const char* signature, void** table_ptr) {
     const PhysicalAddress* xsdt_arr =
         (const PhysicalAddress*)((PhysicalAddress)g_xsdt + sizeof(XSDT));
-    const uint64_t entries = (g_xsdt->len - sizeof(XSDT)) / sizeof(PhysicalAddress);
+    const uint64_t entries = (g_xsdt->length - sizeof(XSDT)) / sizeof(PhysicalAddress);
     for (uint64_t i = 0; i < entries; ++i) {
         const ACPISDTHeader* header = (const ACPISDTHeader*)xsdt_arr[i];
         if (memcmp(header->signature, signature, 4) == 0) {

--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -111,10 +111,10 @@ VirtualAddress get_virtual_acpi_address(PhysicalAddress physical) {
         // Find address in range
         if (entry->phys < physical && entry->phys + entry->size > physical)
             return (entry->virt - entry->phys + physical);
-        }
+    }
 
     return 0;
-    }
+}
 
 void initialize_acpi(PhysicalAddress rsdp_ptr) {
     RSDP* rsdp = (RSDP*)get_virtual_acpi_address(rsdp_ptr);
@@ -134,7 +134,7 @@ void initialize_acpi(PhysicalAddress rsdp_ptr) {
         // sum = 0 by condition
         for (int i = 20; i < 36; i++) sum += ((uint8_t*)rsdp)[i];
         KERNEL_ASSERT(!sum, "INVALID RSDP");
-}
+    }
 
     g_xsdt = (const XSDT*)get_virtual_acpi_address(rsdp->xsdt_phys_addr);
     KERNEL_ASSERT(g_xsdt, "XSDT VIRTUAL ADDRESS NOT FOUND");

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -38,7 +38,7 @@ __attribute__((naked)) void jump_to_kernel_virtual(PhysicalAddress __attribute__
         "lretq\n");
 }
 
-_Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
+_Noreturn void kernel_entry(void* mm, void* fb, PhysicalAddress rsdp) {
     // Set frame buffer
     memcpy((void*)&g_frame_buffer, (void*)fb, sizeof(g_frame_buffer));
     clear_screen(g_bg_color);
@@ -61,17 +61,25 @@ _Noreturn void kernel_entry(void* mm, void* fb, void* rsdp) {
     remap_framebuffer();
     put_string("Framebuffer remapped to virtual address space", 10, 11);
 
+    prepare_acpi_memory(mm);
+    put_string("Prepared ACPI memory", 10, 12);
+
     // This disables interrupts
     setup_gdt_and_tss();
-    put_string("Global descriptor table initalized", 10, 12);
+    put_string("Global descriptor table initalized", 10, 13);
 
     // Interrupts are enabled here.
     // They can be registered using the register_interrupt(...) function
     setup_idt();
-    put_string("Interrupt descriptor table initalized", 10, 13);
+    put_string("Interrupt descriptor table initalized", 10, 14);
+
+    // After this point all physical addresses have to be mapped to virtual memory
+    // NOTE: The memory pointed at by mm and fb should NOT be used after this point
+    free_uefi_memory_and_remove_identity_mapping(mm);
+    put_string("UEFI data deallocated and identity mapping removed", 10, 15);
 
     initialize_acpi(rsdp);
-    put_string("ACPI initialized", 10, 14);
+    put_string("ACPI Initialized", 10, 16);
 
     enumerate_pci_devices();
     put_string("PCI devices enumerated", 10, 15);

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -82,12 +82,7 @@ _Noreturn void kernel_entry(void* mm, void* fb, PhysicalAddress rsdp) {
     put_string("ACPI Initialized", 10, 16);
 
     enumerate_pci_devices();
-    put_string("PCI devices enumerated", 10, 15);
-
-    // After this point all physical addresses have to be mapped to virtual memory
-    // NOTE: The memory pointed at by mm and fb should NOT be used after this point
-    free_uefi_memory_and_remove_identity_mapping(mm);
-    put_string("UEFI data deallocated and identity mapping removed", 10, 16);
+    put_string("PCI devices enumerated", 10, 17);
 
     // This function can't return
     while (1)

--- a/kernel/src/pci.c
+++ b/kernel/src/pci.c
@@ -62,7 +62,7 @@ void enumerate_pci_devices() {
 
     const PhysicalAddress mcfg_addr = (PhysicalAddress)mcfg;
     const MCFGEntry* mcfg_arr = (MCFGEntry*)(mcfg_addr + sizeof(MCFG));
-    const uint64_t entries = (mcfg->header.len - sizeof(MCFG)) / sizeof(MCFGEntry);
+    const uint64_t entries = (mcfg->header.length - sizeof(MCFG)) / sizeof(MCFGEntry);
 
     for (uint64_t i = 0; i < entries; ++i) {
         const PhysicalAddress base_phys_addr = mcfg_arr[i].base_address;

--- a/kernel/src/pci.c
+++ b/kernel/src/pci.c
@@ -22,7 +22,7 @@ typedef struct {
 
 typedef struct {
     VirtualAddress next : 48;
-    PhysicalAddress config_phys_addr : 38;
+    VirtualAddress config_space : 36;
     union {
         struct {
             uint8_t revision_ID;
@@ -37,30 +37,25 @@ typedef struct {
 
 PCIDeviceEntry* g_pci_device_list = 0;
 
-bool get_pci_device(PhysicalAddress* config_space_phys_addr, uint32_t type, uint32_t mask) {
+PCIConfigSpace0* get_pci_device(uint32_t type, uint32_t mask) {
     PCIDeviceEntry* device_entry = g_pci_device_list;
     while (device_entry != 0) {
-        if ((device_entry->type & mask) == type) {
-            *config_space_phys_addr = device_entry->config_phys_addr << 12;
-            return true;
-        }
+        if ((device_entry->type & mask) == type)
+            return (PCIConfigSpace0*)SIGN_EXT_ADDR(device_entry->config_space << 12);
+
         device_entry = (PCIDeviceEntry*)SIGN_EXT_ADDR(device_entry->next);
     }
-    return false;
+
+    return 0;
 }
 
 void enumerate_pci_devices() {
     _Static_assert(sizeof(PCIDeviceEntry) == 16, "PCIDeviceEntry not 16 bytes");
 
-    const MCFG* mcfg = ({
-        void* table_ptr;
-        const bool success = find_table("MCFG", &table_ptr);
-        KERNEL_ASSERT(success, "MCFG could not be found")
+    const MCFG* mcfg = (const MCFG*)find_table("MCFG");
+    KERNEL_ASSERT(mcfg, "MCFG TABLE NOT FOUND");
 
-        (const MCFG*)table_ptr;
-    });
-
-    const PhysicalAddress mcfg_addr = (PhysicalAddress)mcfg;
+    const VirtualAddress mcfg_addr = (VirtualAddress)mcfg;
     const MCFGEntry* mcfg_arr = (MCFGEntry*)(mcfg_addr + sizeof(MCFG));
     const uint64_t entries = (mcfg->header.length - sizeof(MCFG)) / sizeof(MCFGEntry);
 
@@ -69,23 +64,32 @@ void enumerate_pci_devices() {
         for (uint16_t bus = mcfg_arr[i].start_bus; bus < mcfg_arr[i].end_bus; ++bus) {
             for (uint8_t device = 0; device < 32; ++device) {
                 for (uint8_t func = 0; func < 8; ++func) {
-                    const PCIConfigSpace0* config_space =
-                        (const PCIConfigSpace0*)(base_phys_addr +
-                                                 (bus << 20 | device << 15 | func << 12));
-                    const bool exists = config_space->vendor_id != 0xffff;
 
+                    PhysicalAddress config_phys_addr =
+                        base_phys_addr + ((bus << 20) | (device << 15) | (func << 12));
+
+                    const PCIConfigSpace0* config_space = (const PCIConfigSpace0*)map_range(
+                        config_phys_addr, 1, PAGING_WRITABLE | PAGING_CACHE_DISABLE);
+
+                    const bool exists = config_space->vendor_id != 0xffff;
                     const bool is_multi_func = (config_space->header_type & 0x80) != 0;
 
-                    if (func > 0 && !is_multi_func) break;
+                    if (func > 0 && !is_multi_func) {
+                        unmap((VirtualAddress)config_space, 1);
+                        break;
+                    }
 
-                    if (!exists) continue;
+                    if (!exists) {
+                        unmap((VirtualAddress)config_space, 1);
+                        continue;
+                    }
 
                     PCIDeviceEntry* device_entry = (PCIDeviceEntry*)get_memory_entry();
                     device_entry->revision_ID = config_space->revision_ID;
                     device_entry->prog_IF = config_space->prog_IF;
                     device_entry->subclass = config_space->subclass;
                     device_entry->class_code = config_space->class_code;
-                    device_entry->config_phys_addr = ((PhysicalAddress)config_space) >> 12;
+                    device_entry->config_space = ((VirtualAddress)config_space) >> 12;
 
                     device_entry->next = (VirtualAddress)g_pci_device_list;
                     g_pci_device_list = device_entry;


### PR DESCRIPTION
## Added ACPI Table validation 
for everything but the rsdp, every table should have a sum & 0xFF be equal
to zero. The rsdp is a bit more complicated due to the fact that it has
went through multiple versions, where both the old and new fields must add
up to zero individually.

## Made PCI and table lookup compatible with paging

Each PCI device section will now be paged and its correct address will be
stored. find_table now returns the correct virtual address.