### PR TITLE
Apic

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/port_io.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/acpi.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pci.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/apic.c
 
   # Memory
   ${CMAKE_CURRENT_SOURCE_DIR}/src/memory.c

--- a/kernel/include/apic.h
+++ b/kernel/include/apic.h
@@ -1,5 +1,6 @@
 // https://wiki.osdev.org/IOAPIC
 // https://habr.com/en/post/446312/ Has a nice graphical overview of APICs
+// https://wiki.osdev.org/MADT
 
 #pragma once
 
@@ -8,6 +9,26 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// 8259 + slave has 16(-1) IRQ lines
+#define MAX_8259_IRQ_COUNT 16
+
+// MADT Structs
+typedef struct {
+    uint8_t ioapic_id;
+    PhysicalAddress physical_address;
+    void* virtual_address;
+    // Starting global system interrupt for ioapic
+    uint32_t gsi_offset;
+    uint32_t used_irqs;
+} __attribute__((packed)) IOAPICInfo;
+
+typedef struct {
+    bool present;
+    uint32_t gsi;
+    // If (flags & 2) then the interrupt is active when low,
+    // and if (flags & 8) then interrupt is level-triggered
+    uint16_t flags;
+} GSIOverrideEntry;
 
 // IOAPIC Structs
 typedef union {
@@ -30,6 +51,18 @@ typedef union {
     };
 } __attribute__((packed)) IOREDTBLEntry;
 
+
+extern LocalAPIC* g_lapic;
+extern GSIOverrideEntry g_gsi_override_table[MAX_8259_IRQ_COUNT];
+
+// Finds, pages and prepares LAPICs and IOAPICs
+void setup_apic();
+
+// Gets the Local APIC id from a ACPI processor id
+bool get_lapic_id(uint8_t acpi_id, uint8_t* lapic_id);
+
+// Gets a pointer to the IOAPICInfo that deals with a certain Global System Interrupt
+IOAPICInfo* get_responsible_ioapic(uint32_t gsi);
 
 // Writes all segments of a IOREDTBL entry
 void read_redtable_entry(void* ioapic_address, uint32_t irq, IOREDTBLEntry* entry);

--- a/kernel/include/apic.h
+++ b/kernel/include/apic.h
@@ -1,0 +1,44 @@
+// https://wiki.osdev.org/IOAPIC
+// https://habr.com/en/post/446312/ Has a nice graphical overview of APICs
+
+#pragma once
+
+#include "memory.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+
+
+// IOAPIC Structs
+typedef union {
+    struct {
+        uint64_t vector : 8;
+        uint64_t delivery_mode : 3;
+        uint64_t destination_mode : 1;
+        uint64_t delivery_status : 1;
+        uint64_t pin_polarity : 1;
+        uint64_t remote_irr : 1;
+        uint64_t trigger_mode : 1;
+        uint64_t mask : 1;
+        uint64_t reserved : 39;
+        uint64_t destination : 8;
+    };
+
+    struct {
+        uint32_t lower_dword;
+        uint32_t upper_dword;
+    };
+} __attribute__((packed)) IOREDTBLEntry;
+
+
+// Writes all segments of a IOREDTBL entry
+void read_redtable_entry(void* ioapic_address, uint32_t irq, IOREDTBLEntry* entry);
+
+// Reads all segments of a IOREDTBL entry
+void write_redtable_entry(void* ioapic_address, uint32_t irq, IOREDTBLEntry* entry);
+
+uint32_t read_ioapic_id(void* ioapic_address);
+uint32_t read_ioapic_version(void* ioapic_address);
+
+// The Max Redirection Entry is "how many IRQs can this I/O APIC handle - 1"
+uint32_t read_ioapic_mre(void* ioapic_address);

--- a/kernel/include/apic.h
+++ b/kernel/include/apic.h
@@ -1,6 +1,7 @@
 // https://wiki.osdev.org/IOAPIC
 // https://habr.com/en/post/446312/ Has a nice graphical overview of APICs
 // https://wiki.osdev.org/MADT
+// https://wiki.osdev.org/APIC
 
 #pragma once
 
@@ -51,6 +52,72 @@ typedef union {
     };
 } __attribute__((packed)) IOREDTBLEntry;
 
+// Local APIC Structs
+typedef struct {
+    const uint32_t isr0 __attribute__((aligned(0x10)));
+    const uint32_t isr1 __attribute__((aligned(0x10)));
+    const uint32_t isr2 __attribute__((aligned(0x10)));
+    const uint32_t isr3 __attribute__((aligned(0x10)));
+    const uint32_t isr4 __attribute__((aligned(0x10)));
+    const uint32_t isr5 __attribute__((aligned(0x10)));
+    const uint32_t isr6 __attribute__((aligned(0x10)));
+    const uint32_t isr7 __attribute__((aligned(0x10)));
+} __attribute__((packed)) ISR;
+
+typedef struct {
+    const uint32_t tmr0 __attribute__((aligned(0x10)));
+    const uint32_t tmr1 __attribute__((aligned(0x10)));
+    const uint32_t tmr2 __attribute__((aligned(0x10)));
+    const uint32_t tmr3 __attribute__((aligned(0x10)));
+    const uint32_t tmr4 __attribute__((aligned(0x10)));
+    const uint32_t tmr5 __attribute__((aligned(0x10)));
+    const uint32_t tmr6 __attribute__((aligned(0x10)));
+    const uint32_t tmr7 __attribute__((aligned(0x10)));
+} __attribute__((packed)) TMR;
+
+typedef struct {
+    const uint32_t irr0 __attribute__((aligned(0x10)));
+    const uint32_t irr1 __attribute__((aligned(0x10)));
+    const uint32_t irr2 __attribute__((aligned(0x10)));
+    const uint32_t irr3 __attribute__((aligned(0x10)));
+    const uint32_t irr4 __attribute__((aligned(0x10)));
+    const uint32_t irr5 __attribute__((aligned(0x10)));
+    const uint32_t irr6 __attribute__((aligned(0x10)));
+    const uint32_t irr7 __attribute__((aligned(0x10)));
+} __attribute__((packed)) IRR;
+
+typedef volatile struct {
+    uint8_t reserved0[0x20] __attribute__((aligned(0x10)));
+    uint32_t id __attribute__((aligned(0x10)));
+    uint32_t version __attribute__((aligned(0x10)));
+    uint8_t reserved1[0x80 - 0x40] __attribute__((aligned(0x10)));
+    uint32_t task_priority __attribute__((aligned(0x10)));
+    const uint32_t arbitration_priority __attribute__((aligned(0x10)));
+    const uint32_t processor_priority __attribute__((aligned(0x10)));
+    uint32_t eoi __attribute__((aligned(0x10)));
+    const uint32_t remote_read __attribute__((aligned(0x10)));
+    uint32_t logical_destination __attribute__((aligned(0x10)));
+    uint32_t destination_format __attribute__((aligned(0x10)));
+    uint32_t spurious_interrupt_vector __attribute__((aligned(0x10)));
+    const ISR in_service __attribute__((aligned(0x10)));
+    const TMR trigger_mode __attribute__((aligned(0x10)));
+    const IRR interrupt_request __attribute__((aligned(0x10)));
+    const uint32_t error_status __attribute__((aligned(0x10)));
+    uint8_t reserved2[0x300 - 0x290] __attribute__((aligned(0x10)));
+    uint32_t icr_send __attribute__((aligned(0x10)));
+    uint32_t icr_data __attribute__((aligned(0x10)));
+    uint32_t lvt_timer __attribute__((aligned(0x10)));
+    uint32_t lvt_thermal_sensor __attribute__((aligned(0x10)));
+    // LVT Performance Monitoring Counters Register
+    uint32_t lvt_pmcr __attribute__((aligned(0x10)));
+    uint32_t lvt_lint0 __attribute__((aligned(0x10)));
+    uint32_t lvt_lint1 __attribute__((aligned(0x10)));
+    uint32_t lvt_error __attribute__((aligned(0x10)));
+    uint32_t initial_count __attribute__((aligned(0x10)));
+    const uint32_t current_count __attribute__((aligned(0x10)));
+    uint8_t reserved4[0x3E0 - 0x3A0] __attribute__((aligned(0x10)));
+    uint32_t divide_configuration __attribute__((aligned(0x10)));
+} __attribute__((packed)) LocalAPIC;
 
 extern LocalAPIC* g_lapic;
 extern GSIOverrideEntry g_gsi_override_table[MAX_8259_IRQ_COUNT];

--- a/kernel/src/apic.c
+++ b/kernel/src/apic.c
@@ -5,6 +5,15 @@
 #include "memory/paging.h"
 #include "kassert.h"
 
+#define MAX_IOAPIC_COUNT 4
+#define MAX_LAPIC_COUNT 16
+
+#define LOCAL_APIC_ENTRY 0
+#define IO_APIC_ENTRY 1
+#define INTERRUPT_SOURCE_OVERRIDE_ENTRY 2
+#define NON_MASKABLE_INTERRUPTS_ENTRY 4
+#define LOCAL_APIC_ADDRESS_OVERRIDE_ENTRY 5
+
 // Gets lower register offset for irq redtable entry
 #define REDTBL_OFFSET(irq) (2 * (irq) + 0x10)
 #define GET_BITRANGE_VALUE(num, lb, ub) (((num) & ((1U << (ub)) - (1U << (lb)))) >> (lb))
@@ -15,6 +24,198 @@ typedef volatile struct {
     uint32_t register_value __attribute__((aligned(0x10)));
 } __attribute__((packed)) IOAPIC;
 
+// MADT Entry structs to avoid offsets, this also makes code super bloated on multiple fronts
+typedef struct {
+    ACPISDTHeader header;
+    uint32_t local_apic_phys_addr;
+    uint32_t flags;
+} __attribute__((packed)) MADT;
+
+typedef struct {
+    uint8_t type;
+    uint8_t length;
+} __attribute__((packed)) MADTEntry;
+
+typedef struct {
+    MADTEntry header;
+    uint8_t processor_id;
+    uint8_t apic_id;
+    uint32_t flags;
+} __attribute__((packed)) LocalAPICEntry;
+
+typedef struct {
+    MADTEntry header;
+    uint8_t ioapic_id;
+    uint8_t reserved;
+    uint32_t ioapic_address;
+    uint32_t global_system_interrupt_base;
+} __attribute__((packed)) IOAPICEntry;
+
+typedef struct {
+    MADTEntry header;
+    uint8_t bus_source;
+    uint8_t irq_source;
+    uint32_t global_system_interrupt;
+    uint16_t flags;
+} __attribute__((packed)) InterruptSourceOverrideEntry;
+
+typedef struct {
+    MADTEntry header;
+    uint8_t acpi_processor_id;
+    uint16_t flags;
+    uint8_t LINT;
+} __attribute__((packed)) NonMaskableInterruptsEntry;
+
+typedef struct {
+    MADTEntry header;
+    uint8_t reserved[2];
+    PhysicalAddress local_apic_phys_addr;
+} __attribute__((packed)) LocalAPICAddressOverrideEntry;
+
+// Pointer to the MMIO responsible for the Local APIC
+LocalAPIC* g_lapic;
+
+// Conversion table from 8259 IRQs to GSI
+GSIOverrideEntry g_gsi_override_table[MAX_8259_IRQ_COUNT];
+
+// References to the MADT's IOAPIC entries, uses g_ioapic_count
+IOAPICInfo g_found_ioapics[MAX_IOAPIC_COUNT];
+uint64_t g_ioapic_count = 0;
+
+// References to the MADT's Local APIC entries, uses g_lapic_count
+LocalAPICEntry* g_found_lapics[MAX_LAPIC_COUNT];
+uint64_t g_lapic_count = 0;
+
+void setup_apic() {
+
+    { // Disable 8259 PIC. According to osdev, the PIC also have to be remapped to not raise
+      // unwanted exceptions. Simply masking the interrupts isn't enough.
+
+        // Start ICW4 Configuration
+        port_out_u8(0x20, 0x11);
+        port_out_u8(0xA0, 0x11);
+
+        // Remap offsets to 0x20 - 0x30
+        port_out_u8(0x21, 0x20);
+        port_out_u8(0xA1, 0x28);
+
+        // Cascade slave
+        port_out_u8(0x21, 0x04);
+        port_out_u8(0xA1, 0x02);
+
+        // ICW4 x8086 mode
+        port_out_u8(0x21, 0x01);
+        port_out_u8(0xA1, 0x01);
+        // end of configuration sequence
+
+        // mask all interrupts
+        port_out_u8(0x21, 0xff);
+        port_out_u8(0xA1, 0xff);
+    }
+
+    const MADT* madt = (const MADT*)find_table("APIC");
+    KERNEL_ASSERT(madt, "MADT NOT FOUND");
+
+    { // Validate MADT
+        bool madt_valid = sdt_is_valid(&madt->header, "APIC");
+        KERNEL_ASSERT(madt_valid, "INVALID MADT");
+    }
+
+    // Fill Override table to have a corrent redirection when GSI = 8259 IRQ.
+    for (int i = 0; i < MAX_8259_IRQ_COUNT; i++) g_gsi_override_table[i].gsi = i;
+
+    PhysicalAddress local_apic_phys_addr = (PhysicalAddress)madt->local_apic_phys_addr;
+    { // Parse MADT
+
+        const void* end = (void*)madt + madt->header.length;
+        void* curr_addr = (void*)madt + sizeof(MADT);
+
+        // Entry offsets are found in
+        while (curr_addr < end) {
+            MADTEntry* entry_header = (MADTEntry*)curr_addr;
+            curr_addr += entry_header->length;
+
+            switch (entry_header->type) {
+                case LOCAL_APIC_ENTRY:
+                    g_found_lapics[g_lapic_count++] = (LocalAPICEntry*)entry_header;
+                    break;
+
+                case IO_APIC_ENTRY: {
+                    const IOAPICEntry* entry = (const IOAPICEntry*)entry_header;
+
+                    IOAPICInfo* ioapic = &g_found_ioapics[g_ioapic_count++];
+                    ioapic->gsi_offset = entry->global_system_interrupt_base;
+                    ioapic->ioapic_id = entry->ioapic_id;
+                    ioapic->physical_address = (PhysicalAddress)entry->ioapic_address;
+
+                    // Page each IOAPIC
+                    ioapic->virtual_address = (void*)map_range(
+                        ioapic->physical_address, 1, PAGING_WRITABLE | PAGING_CACHE_DISABLE);
+
+                    ioapic->used_irqs = 1 + read_ioapic_mre(ioapic->virtual_address);
+
+                    { // ID mismatch could indicate that the IOAPIC can't be read
+                        const uint8_t fetched_id = (uint8_t)read_ioapic_id(ioapic->virtual_address);
+                        const uint8_t stored_id = ioapic->ioapic_id;
+
+                        KERNEL_ASSERT(stored_id == fetched_id, "ID MISMATCH WHEN LOADING IOAPIC");
+                    }
+
+                    break;
+                }
+
+                case INTERRUPT_SOURCE_OVERRIDE_ENTRY: {
+                    const InterruptSourceOverrideEntry* entry =
+                        (const InterruptSourceOverrideEntry*)entry_header;
+
+                    GSIOverrideEntry* gsi_override_entry = &g_gsi_override_table[entry->irq_source];
+                    gsi_override_entry->present = true;
+                    gsi_override_entry->gsi = entry->global_system_interrupt;
+                    gsi_override_entry->flags = entry->flags;
+
+                    break;
+                }
+
+                case LOCAL_APIC_ADDRESS_OVERRIDE_ENTRY: {
+                    const LocalAPICAddressOverrideEntry* entry =
+                        (const LocalAPICAddressOverrideEntry*)entry_header;
+
+                    local_apic_phys_addr = entry->local_apic_phys_addr;
+                    break;
+                }
+
+                default: break;
+            }
+        }
+    }
+
+}
+
+IOAPICInfo* get_responsible_ioapic(uint32_t gsi) {
+    for (uint64_t i = 0; i < g_ioapic_count; i++) {
+        IOAPICInfo* ioapic = &g_found_ioapics[i];
+
+        // Check if ioapic contains the GSI
+        if (ioapic->gsi_offset <= gsi && ioapic->gsi_offset + ioapic->used_irqs > gsi) {
+            return ioapic;
+        }
+    }
+
+    return (IOAPICInfo*)0;
+}
+
+bool get_lapic_id(uint8_t acpi_id, uint8_t* lapic_id) {
+    for (uint64_t i = 0; i < g_lapic_count; i++) {
+        LocalAPICEntry* entry = g_found_lapics[i];
+
+        if (entry->processor_id == acpi_id) {
+            *lapic_id = entry->apic_id;
+            return true;
+        }
+    }
+
+    return false;
+}
 
 uint32_t read_ioapic_register(void* ioapic_address, uint32_t offset) {
     IOAPIC* ioapic = (IOAPIC*)ioapic_address;

--- a/kernel/src/apic.c
+++ b/kernel/src/apic.c
@@ -1,0 +1,68 @@
+#include "apic.h"
+
+#include "acpi.h"
+#include "port_io.h"
+#include "memory/paging.h"
+#include "kassert.h"
+
+// Gets lower register offset for irq redtable entry
+#define REDTBL_OFFSET(irq) (2 * (irq) + 0x10)
+#define GET_BITRANGE_VALUE(num, lb, ub) (((num) & ((1U << (ub)) - (1U << (lb)))) >> (lb))
+
+// IOAPIC IO
+typedef volatile struct {
+    uint32_t current_register __attribute__((aligned(0x10)));
+    uint32_t register_value __attribute__((aligned(0x10)));
+} __attribute__((packed)) IOAPIC;
+
+
+uint32_t read_ioapic_register(void* ioapic_address, uint32_t offset) {
+    IOAPIC* ioapic = (IOAPIC*)ioapic_address;
+
+    ioapic->current_register = offset;
+    return ioapic->register_value;
+}
+
+void write_ioapic_register(void* ioapic_address, uint32_t offset, uint32_t value) {
+    IOAPIC* ioapic = (IOAPIC*)ioapic_address;
+
+    ioapic->current_register = offset;
+    ioapic->register_value = value;
+}
+
+uint32_t read_ioapic_id(void* ioapic_address) {
+    const uint32_t r0 = read_ioapic_register(ioapic_address, 0);
+
+    // Bits 24-27 contains the id
+    return GET_BITRANGE_VALUE(r0, 24, 27);
+}
+
+uint32_t read_ioapic_version(void* ioapic_address) {
+    const uint32_t r1 = read_ioapic_register(ioapic_address, 1);
+
+    // Bits 0-8 contains the id
+    return GET_BITRANGE_VALUE(r1, 0, 8);
+}
+
+uint32_t read_ioapic_mre(void* ioapic_address) {
+    const uint32_t r1 = read_ioapic_register(ioapic_address, 1);
+
+    // Bits 16-24 contains the Max Redirection Entry
+    return GET_BITRANGE_VALUE(r1, 16, 24);
+}
+
+void read_redtable_entry(void* ioapic_address, uint32_t irq, IOREDTBLEntry* entry) {
+    const uint8_t lower_offset = REDTBL_OFFSET(irq);
+    const uint8_t upper_offset = lower_offset + 1;
+
+    entry->lower_dword = read_ioapic_register(ioapic_address, lower_offset);
+    entry->upper_dword = read_ioapic_register(ioapic_address, upper_offset);
+}
+
+void write_redtable_entry(void* ioapic_address, uint32_t irq, IOREDTBLEntry* entry) {
+    const uint8_t lower_offset = REDTBL_OFFSET(irq);
+    const uint8_t upper_offset = lower_offset + 1;
+
+    write_ioapic_register(ioapic_address, lower_offset, entry->lower_dword);
+    write_ioapic_register(ioapic_address, upper_offset, entry->upper_dword);
+}

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -5,6 +5,7 @@
 #include "idt.h"
 #include "acpi.h"
 #include "pci.h"
+#include "apic.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -83,6 +84,9 @@ _Noreturn void kernel_entry(void* mm, void* fb, PhysicalAddress rsdp) {
 
     enumerate_pci_devices();
     put_string("PCI devices enumerated", 10, 17);
+
+    setup_apic();
+    put_string("APIC(s) set up and usable", 10, 18);
 
     // This function can't return
     while (1)


### PR DESCRIPTION
Adds a MADT parser and the ability to write to IO-APICs and Local APICs.

To hook the ps/2 kb interrupt you have to rewrite the correct ioapic and IOREDTBL entry.

Heres some example pseudocode that should enable keyboard interrput at 0x21
```c
    // 1 is the PIC irq for ps/2 kb
    const uint32_t gsi = g_gsi_override_table[1].gsi;
    IOAPICInfo* ioapic = get_responsible_ioapic(gsi);

    KERNEL_ASSERT(ioapic, "NO IOAPIC THAT USES KB WAS FOUND");

    const uint32_t irq = gsi - ioapic->gsi_offset;

    IOREDTBLEntry entry;
    read_redtable_entry(ioapic, irq, &entry);
    // Enable interrupt
    entry.mask = 0;

    // Fixed delivery mode
    entry.delivery_mode = 0;

    // Interrupt Vector
    entry.vector = 0x21;

    // Destination lapic
    entry.destination = g_lapic->id;

    write_redtable_entry(ioapic, irq, &entry);
``` 
