### PR TITLE
Memory improvements

### DIFF
--- a/kernel/include/memory.h
+++ b/kernel/include/memory.h
@@ -1,10 +1,7 @@
 #pragma once
-#include <stdint.h>
+#include "memory/defs.h"
 
-#define PAGE_SIZE 0x1000ULL
 
-typedef uint64_t PhysicalAddress;
-typedef uint64_t VirtualAddress;
 
 void initialize_memory(void* uefi_memory_map, PhysicalAddress* kernel_phys_addr,
                        VirtualAddress* kernel_virt_addr);

--- a/kernel/include/memory.h
+++ b/kernel/include/memory.h
@@ -8,6 +8,12 @@ void* alloc_pages(uint64_t pages, PagingFlags paging_flags);
 // Frees pages allocated by alloc_pages
 void free_pages(void* ptr, uint64_t pages);
 
+// Allocates physically contiguos pages which are mapped with flags applied
+void* alloc_pages_contiguous(uint64_t pages, PagingFlags paging_flags);
+
+// Frees pages allocated by alloc_pages_contiguos
+void free_pages_contiguous(void* ptr, uint64_t pages);
+
 void initialize_memory(void* uefi_memory_map, PhysicalAddress* kernel_phys_addr,
                        VirtualAddress* kernel_virt_addr);
 

--- a/kernel/include/memory.h
+++ b/kernel/include/memory.h
@@ -1,7 +1,12 @@
 #pragma once
 #include "memory/defs.h"
+#include "memory/paging.h"
 
+// Allocates physically non contiguos pages which are mapped with flags applied
+void* alloc_pages(uint64_t pages, PagingFlags paging_flags);
 
+// Frees pages allocated by alloc_pages
+void free_pages(void* ptr, uint64_t pages);
 
 void initialize_memory(void* uefi_memory_map, PhysicalAddress* kernel_phys_addr,
                        VirtualAddress* kernel_virt_addr);

--- a/kernel/include/memory/defs.h
+++ b/kernel/include/memory/defs.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <stdint.h>
+
+#define PAGE_SIZE 0x1000ULL
+
+typedef uint64_t PhysicalAddress;
+typedef uint64_t VirtualAddress;

--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -22,6 +22,9 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
 // Get the size of blocks of specified order
 uint64_t get_order_block_size(uint8_t order);
 
+// Frees frame allocation list
+void free_frame_allocation_entries(PageFrameAllocation* allocations);
+
 // Allocate page frames (allocation may consist of several non-contiguos blocks)
 // Underlying memory for PageFrameAllocation structs is owned by the allocator
 PageFrameAllocation* alloc_frames(uint64_t pages);

--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -19,8 +19,8 @@ void alloc_frame_allocator_memory(void* uefi_memory_map, PhysicalAddress* phys_a
 void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
                                 void* uefi_memory_map, uint64_t entry_pool_pages);
 
-// Get the size of blocks of specified order
-uint64_t get_order_block_size(uint8_t order);
+// Get the size of the specified frame order
+uint64_t get_frame_order_size(uint8_t order);
 
 // Get the min size order from number of pages
 // Return FRAME_ORDERS if order doesn't exist

--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -22,6 +22,10 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
 // Get the size of blocks of specified order
 uint64_t get_order_block_size(uint8_t order);
 
+// Get the min size order from number of pages
+// Return FRAME_ORDERS if order doesn't exist
+uint8_t get_min_size_order(uint64_t pages);
+
 // Frees frame allocation list
 void free_frame_allocation_entries(PageFrameAllocation* allocations);
 

--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "memory.h"
+#include "memory/defs.h"
 
 #include <stdbool.h>
 

--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -38,7 +38,7 @@ PageFrameAllocation* alloc_frames(uint64_t pages);
 void free_frames(PageFrameAllocation* allocation);
 
 // Allocate a block of contiguos memory (useful for DMA)
-bool alloc_frames_contiguos(uint8_t order, PhysicalAddress* out_addr);
+bool alloc_frames_contiguos(uint64_t pages, PhysicalAddress* out_addr);
 
 // Free block of contiguos memory
-void free_frames_contiguos(PhysicalAddress addr, uint8_t order);
+void free_frames_contiguos(PhysicalAddress addr, uint64_t pages);

--- a/kernel/include/memory/frame_allocator.h
+++ b/kernel/include/memory/frame_allocator.h
@@ -22,9 +22,9 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
 // Get the size of the specified frame order
 uint64_t get_frame_order_size(uint8_t order);
 
-// Get the min size order from number of pages
+// Get the min size frame order from number of pages
 // Return FRAME_ORDERS if order doesn't exist
-uint8_t get_min_size_order(uint64_t pages);
+uint8_t get_min_size_frame_order(uint64_t pages);
 
 // Frees frame allocation list
 void free_frame_allocation_entries(PageFrameAllocation* allocations);

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "memory.h"
+#include "memory/defs.h"
 #include "memory/frame_allocator.h"
 
 #define PAGING_WRITABLE 1

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -20,6 +20,9 @@ VirtualAddress map_range(PhysicalAddress phys_addr, uint64_t pages, PagingFlags 
 // Unmaps virtual address space
 void unmap(VirtualAddress virt_addr, uint64_t pages);
 
+// Unmaps virtual address range and frees previously mapped frames
+void unmap_and_free_frames(VirtualAddress virt_addr, uint64_t pages);
+
 // Translates a virtual address into the corresponding physical address
 // Returns false if the virtual address isn't mapped
 bool get_physical_address(VirtualAddress virt_addr, PhysicalAddress* phys_addr);

--- a/kernel/src/memory.c
+++ b/kernel/src/memory.c
@@ -19,6 +19,22 @@ void* alloc_pages(uint64_t pages, PagingFlags paging_flags) {
 
 void free_pages(void* ptr, uint64_t pages) { unmap_and_free_frames((VirtualAddress)ptr, pages); }
 
+void* alloc_pages_contiguous(uint64_t pages, PagingFlags paging_flags) {
+    PhysicalAddress phys_addr;
+    if (!alloc_frames_contiguos(pages, &phys_addr)) return 0;
+
+    return (void*)map_range(phys_addr, pages, paging_flags);
+}
+
+void free_pages_contiguous(void* ptr, uint64_t pages) {
+    PhysicalAddress phys_addr;
+    const bool success = get_physical_address((VirtualAddress)ptr, &phys_addr);
+    KERNEL_ASSERT(success, "Physical address does not exist");
+
+    unmap((VirtualAddress)ptr, pages);
+    free_frames_contiguos(phys_addr, pages);
+}
+
 uint64_t get_memory_size() { return g_memory_size; }
 
 void initialize_memory(void* uefi_memory_map, PhysicalAddress* kernel_phys_addr,

--- a/kernel/src/memory.c
+++ b/kernel/src/memory.c
@@ -7,6 +7,18 @@
 
 uint64_t g_memory_size = 0;
 
+void* alloc_pages(uint64_t pages, PagingFlags paging_flags) {
+    PageFrameAllocation* allocation = alloc_frames(pages);
+    if (allocation == 0) return 0;
+
+    void* ptr = (void*)map_allocation(allocation, paging_flags);
+
+    free_frame_allocation_entries(allocation);
+    return ptr;
+}
+
+void free_pages(void* ptr, uint64_t pages) { unmap_and_free_frames((VirtualAddress)ptr, pages); }
+
 uint64_t get_memory_size() { return g_memory_size; }
 
 void initialize_memory(void* uefi_memory_map, PhysicalAddress* kernel_phys_addr,

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -22,11 +22,11 @@ struct {
     uint64_t* buddy_map;
 } g_free_lists[FRAME_ORDERS] = {0};
 
-uint64_t g_block_sizes[FRAME_ORDERS];
+uint64_t g_frame_order_sizes[FRAME_ORDERS];
 
 uint64_t get_frame_order_size(uint8_t order) {
     KERNEL_ASSERT(order < FRAME_ORDERS, "Not an order")
-    return g_block_sizes[order];
+    return g_frame_order_sizes[order];
 }
 
 uint8_t get_min_size_frame_order(uint64_t pages) {
@@ -35,7 +35,7 @@ uint8_t get_min_size_frame_order(uint64_t pages) {
     const uint64_t order_0_blocks =
         MIN_FRAME_ORDER_SIZE == PAGE_SIZE
             ? pages
-            : ((pages * PAGE_SIZE) + g_block_sizes[0] - 1) / g_block_sizes[0];
+            : ((pages * PAGE_SIZE) + g_frame_order_sizes[0] - 1) / g_frame_order_sizes[0];
 
     // The result of __builtin_clzll is undefined when input is zero
     if (order_0_blocks == 1) return 0;
@@ -54,7 +54,7 @@ void free_frame_allocation_entries(PageFrameAllocation* allocations) {
 // Calculate array index and bit index for buddy corresponding to address and order
 void calc_buddy_index(uint64_t addr, uint8_t order, uint64_t* arr_index, uint8_t* bit_index) {
     KERNEL_ASSERT(order < (FRAME_ORDERS - 1), "Order does not have a buddy map")
-    *arr_index = addr / g_block_sizes[order];
+    *arr_index = addr / g_frame_order_sizes[order];
     *arr_index -= (*arr_index) % 2;
     *arr_index /= 2;
 
@@ -90,7 +90,7 @@ void split_entry(ListEntry* entry, uint8_t order) {
     ListEntry* left = entry;
     ListEntry* right = (ListEntry*)get_memory_entry();
 
-    right->addr = left->addr + g_block_sizes[order - 1];
+    right->addr = left->addr + g_frame_order_sizes[order - 1];
     right->next = g_free_lists[order - 1].head;
 
     left->next = right;
@@ -110,7 +110,7 @@ PageFrameAllocation* alloc_frames(uint64_t pages) {
         int8_t order_to_alloc = 0;
         while (order_to_alloc < FRAME_ORDERS) {
             // Size big enough for order
-            if (size < g_block_sizes[order_to_alloc]) break;
+            if (size < g_frame_order_sizes[order_to_alloc]) break;
 
             ++order_to_alloc;
         }
@@ -179,7 +179,7 @@ PageFrameAllocation* alloc_frames(uint64_t pages) {
             back->next = 0;
         }
 
-        size -= g_block_sizes[order_to_alloc];
+        size -= g_frame_order_sizes[order_to_alloc];
     }
 
     return front;
@@ -212,11 +212,11 @@ void free_frames(PageFrameAllocation* allocation) {
             g_free_lists[order].head = entry->next;
 
             uint64_t other_addr = entry->addr;
-            if (entry->addr % g_block_sizes[order + 1] == 0) {
-                other_addr += g_block_sizes[order];
+            if (entry->addr % g_frame_order_sizes[order + 1] == 0) {
+                other_addr += g_frame_order_sizes[order];
             }
             else {
-                other_addr -= g_block_sizes[order];
+                other_addr -= g_frame_order_sizes[order];
             }
 
             ListEntry* buddy_entry = g_free_lists[order].head;
@@ -311,10 +311,10 @@ bool remove_range(PhysicalAddress addr, uint64_t pages) {
         int32_t order_to_alloc = 1;
         while (order_to_alloc < FRAME_ORDERS) {
             // Address aligns with block size of order
-            const bool addr_align = (addr % g_block_sizes[order_to_alloc]) == 0;
+            const bool addr_align = (addr % g_frame_order_sizes[order_to_alloc]) == 0;
 
             // Size big enough for order
-            const bool big_enough = size >= g_block_sizes[order_to_alloc];
+            const bool big_enough = size >= g_frame_order_sizes[order_to_alloc];
 
             if (!addr_align || !big_enough) break;
 
@@ -327,7 +327,7 @@ bool remove_range(PhysicalAddress addr, uint64_t pages) {
             ListEntry* curr_entry = g_free_lists[order].head;
             ListEntry* last_entry = 0;
             while (curr_entry != 0 &&
-                   !range_contains(addr, curr_entry->addr, g_block_sizes[order])) {
+                   !range_contains(addr, curr_entry->addr, g_frame_order_sizes[order])) {
                 last_entry = curr_entry;
                 curr_entry = curr_entry->next;
             }
@@ -363,8 +363,8 @@ bool remove_range(PhysicalAddress addr, uint64_t pages) {
             }
         }
 
-        size -= g_block_sizes[order_to_alloc];
-        addr += g_block_sizes[order_to_alloc];
+        size -= g_frame_order_sizes[order_to_alloc];
+        addr += g_frame_order_sizes[order_to_alloc];
     }
 
     return true;
@@ -373,9 +373,9 @@ bool remove_range(PhysicalAddress addr, uint64_t pages) {
 void alloc_frame_allocator_memory(void* uefi_memory_map, PhysicalAddress* phys_addr,
                                   uint64_t* total_pages, uint64_t* entry_pool_pages) {
     // Calculate block sizes
-    g_block_sizes[0] = MIN_FRAME_ORDER_SIZE;
+    g_frame_order_sizes[0] = MIN_FRAME_ORDER_SIZE;
     for (uint64_t i = 1; i < FRAME_ORDERS; ++i) {
-        g_block_sizes[i] = g_block_sizes[i - 1] * 2;
+        g_frame_order_sizes[i] = g_frame_order_sizes[i - 1] * 2;
     }
 
     // Calculate size required by bitmaps
@@ -384,14 +384,14 @@ void alloc_frame_allocator_memory(void* uefi_memory_map, PhysicalAddress* phys_a
         // List entries required at start by all max order blocks
         // We double the amount of free list entries required at the start
         const uint64_t free_list_entries =
-            (get_memory_size() / g_block_sizes[FRAME_ORDERS - 1]) * 2;
+            (get_memory_size() / g_frame_order_sizes[FRAME_ORDERS - 1]) * 2;
 
         *entry_pool_pages =
             round_up_to_multiple(free_list_entries * sizeof(ListEntry), PAGE_SIZE) / PAGE_SIZE;
 
         // Calculate memory required by bitmaps
         for (int i = 0; i < (FRAME_ORDERS - 1); ++i) {
-            total_bitmaps_size += get_memory_size() / g_block_sizes[i];
+            total_bitmaps_size += get_memory_size() / g_frame_order_sizes[i];
         }
 
         total_bitmaps_size = round_up_to_multiple(total_bitmaps_size, PAGE_SIZE) / PAGE_SIZE;
@@ -444,7 +444,7 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
         // Populate buddy maps
         for (uint64_t i = 0; i < (FRAME_ORDERS - 1); ++i) {
             g_free_lists[i].buddy_map = (uint64_t*)virt_addr;
-            virt_addr += get_memory_size() / g_block_sizes[i];
+            virt_addr += get_memory_size() / g_frame_order_sizes[i];
         }
     }
 
@@ -455,16 +455,16 @@ void initialize_frame_allocator(VirtualAddress virt_addr, uint64_t total_pages,
         // Add first entry to free list
         ListEntry* curr_entry = (ListEntry*)get_memory_entry();
         curr_entry->addr = curr_addr;
-        curr_addr += g_block_sizes[FRAME_ORDERS - 1];
+        curr_addr += g_frame_order_sizes[FRAME_ORDERS - 1];
         g_free_lists[FRAME_ORDERS - 1].head = curr_entry;
 
-        const uint64_t block_count = get_memory_size() / g_block_sizes[FRAME_ORDERS - 1];
+        const uint64_t block_count = get_memory_size() / g_frame_order_sizes[FRAME_ORDERS - 1];
         for (uint64_t i = 1; i < block_count; ++i) {
             if (curr_addr >= get_memory_size()) break;
 
             ListEntry* next_entry = (ListEntry*)get_memory_entry();
             next_entry->addr = curr_addr;
-            curr_addr += g_block_sizes[FRAME_ORDERS - 1];
+            curr_addr += g_frame_order_sizes[FRAME_ORDERS - 1];
 
             curr_entry->next = next_entry;
             curr_entry = next_entry;

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -190,6 +190,8 @@ void free_frames(PageFrameAllocation* allocation) {
     while (allocation != 0) {
         uint8_t order = allocation->order;
 
+        KERNEL_ASSERT(order < FRAME_ORDERS, "Not an order")
+
         // Convert allocation to entry
         ListEntry* entry = (ListEntry*)allocation;
         entry->addr = allocation->addr;

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -8,7 +8,7 @@
 
 #include <string.h>
 
-#define MIN_BLOCK_SIZE PAGE_SIZE
+#define MIN_FRAME_ORDER_SIZE PAGE_SIZE
 
 // Free list entry
 typedef struct {
@@ -33,7 +33,7 @@ uint8_t get_min_size_frame_order(uint64_t pages) {
     KERNEL_ASSERT(pages != 0, "Can't have a zero sized allocation")
 
     const uint64_t order_0_blocks =
-        MIN_BLOCK_SIZE == PAGE_SIZE
+        MIN_FRAME_ORDER_SIZE == PAGE_SIZE
             ? pages
             : ((pages * PAGE_SIZE) + g_block_sizes[0] - 1) / g_block_sizes[0];
 
@@ -373,7 +373,7 @@ bool remove_range(PhysicalAddress addr, uint64_t pages) {
 void alloc_frame_allocator_memory(void* uefi_memory_map, PhysicalAddress* phys_addr,
                                   uint64_t* total_pages, uint64_t* entry_pool_pages) {
     // Calculate block sizes
-    g_block_sizes[0] = MIN_BLOCK_SIZE;
+    g_block_sizes[0] = MIN_FRAME_ORDER_SIZE;
     for (uint64_t i = 1; i < FRAME_ORDERS; ++i) {
         g_block_sizes[i] = g_block_sizes[i - 1] * 2;
     }

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -258,7 +258,8 @@ void free_frames(PageFrameAllocation* allocation) {
     }
 }
 
-bool alloc_frames_contiguos(uint8_t order_to_alloc, PhysicalAddress* out_addr) {
+bool alloc_frames_contiguos(uint64_t pages, PhysicalAddress* out_addr) {
+    const uint8_t order_to_alloc = get_min_size_order(pages);
     KERNEL_ASSERT(order_to_alloc < FRAME_ORDERS, "Not an order")
 
     // Split bigger blocks if none of the correct size are available
@@ -294,10 +295,10 @@ bool alloc_frames_contiguos(uint8_t order_to_alloc, PhysicalAddress* out_addr) {
     return true;
 }
 
-void free_frames_contiguos(PhysicalAddress addr, uint8_t order) {
+void free_frames_contiguos(PhysicalAddress addr, uint64_t pages) {
     PageFrameAllocation* allocation = (PageFrameAllocation*)get_memory_entry();
     allocation->addr = addr;
-    allocation->order = order;
+    allocation->order = get_min_size_order(pages);
 
     free_frames(allocation);
 }

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -29,6 +29,20 @@ uint64_t get_order_block_size(uint8_t order) {
     return g_block_sizes[order];
 }
 
+uint8_t get_min_size_order(uint64_t pages) {
+    KERNEL_ASSERT(pages != 0, "Can't have a zero sized allocation")
+
+    const uint64_t order_0_blocks =
+        MIN_BLOCK_SIZE == PAGE_SIZE
+            ? pages
+            : ((pages * PAGE_SIZE) + g_block_sizes[0] - 1) / g_block_sizes[0];
+
+    // The result of __builtin_clzll is undefined when input is zero
+    if (order_0_blocks == 1) return 0;
+
+    return MIN(64 - __builtin_clzll(order_0_blocks - 1), FRAME_ORDERS);
+}
+
 void free_frame_allocation_entries(PageFrameAllocation* allocations) {
     while (allocations != 0) {
         MemoryEntry* memory_entry = (MemoryEntry*)allocations;

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -29,6 +29,14 @@ uint64_t get_order_block_size(uint8_t order) {
     return g_block_sizes[order];
 }
 
+void free_frame_allocation_entries(PageFrameAllocation* allocations) {
+    while (allocations != 0) {
+        MemoryEntry* memory_entry = (MemoryEntry*)allocations;
+        allocations = allocations->next;
+        free_memory_entry(memory_entry);
+    }
+}
+
 // Calculate array index and bit index for buddy corresponding to address and order
 void calc_buddy_index(uint64_t addr, uint8_t order, uint64_t* arr_index, uint8_t* bit_index) {
     KERNEL_ASSERT(order < (FRAME_ORDERS - 1), "Order does not have a buddy map")

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -24,7 +24,7 @@ struct {
 
 uint64_t g_block_sizes[FRAME_ORDERS];
 
-uint64_t get_order_block_size(uint8_t order) {
+uint64_t get_frame_order_size(uint8_t order) {
     KERNEL_ASSERT(order < FRAME_ORDERS, "Not an order")
     return g_block_sizes[order];
 }

--- a/kernel/src/memory/frame_allocator.c
+++ b/kernel/src/memory/frame_allocator.c
@@ -29,7 +29,7 @@ uint64_t get_frame_order_size(uint8_t order) {
     return g_block_sizes[order];
 }
 
-uint8_t get_min_size_order(uint64_t pages) {
+uint8_t get_min_size_frame_order(uint64_t pages) {
     KERNEL_ASSERT(pages != 0, "Can't have a zero sized allocation")
 
     const uint64_t order_0_blocks =
@@ -259,7 +259,7 @@ void free_frames(PageFrameAllocation* allocation) {
 }
 
 bool alloc_frames_contiguos(uint64_t pages, PhysicalAddress* out_addr) {
-    const uint8_t order_to_alloc = get_min_size_order(pages);
+    const uint8_t order_to_alloc = get_min_size_frame_order(pages);
     KERNEL_ASSERT(order_to_alloc < FRAME_ORDERS, "Not an order")
 
     // Split bigger blocks if none of the correct size are available
@@ -298,7 +298,7 @@ bool alloc_frames_contiguos(uint64_t pages, PhysicalAddress* out_addr) {
 void free_frames_contiguos(PhysicalAddress addr, uint64_t pages) {
     PageFrameAllocation* allocation = (PageFrameAllocation*)get_memory_entry();
     allocation->addr = addr;
-    allocation->order = get_min_size_order(pages);
+    allocation->order = get_min_size_frame_order(pages);
 
     free_frames(allocation);
 }

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -309,10 +309,10 @@ void unmap(VirtualAddress virt_addr, uint64_t pages) {
     add_range_to_free_list(virt_addr, pages);
 
     uint16_t pd_index = GET_LEVEL_INDEX(virt_addr, PDP);
-    PageEntry* pd = get_or_alloc_page_entries(&g_kernel_pdp[pd_index]);
+    PageEntry* pd = get_page_entries(&g_kernel_pdp[pd_index]);
 
     uint16_t pt_index = GET_LEVEL_INDEX(virt_addr, PD);
-    PageEntry* pt = get_or_alloc_page_entries(&pd[pt_index]);
+    PageEntry* pt = get_page_entries(&pd[pt_index]);
     for (uint64_t i = 0; i < pages; ++i) {
         const uint16_t index = GET_LEVEL_INDEX(virt_addr, PT);
         pt[index].value = 0;

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -126,7 +126,7 @@ PageEntry* get_or_alloc_page_entries(PageEntry* entry) {
 
             while (allocation != 0) {
                 // Add page to page entry mapping list
-                uint64_t size = get_order_block_size(allocation->order);
+                uint64_t size = get_frame_order_size(allocation->order);
                 PhysicalAddress phys_addr = allocation->addr;
                 while (size != 0) {
                     MappingEntry* mapping_entry = (MappingEntry*)get_memory_entry();
@@ -266,7 +266,7 @@ VirtualAddress map_allocation(PageFrameAllocation* allocation, PagingFlags flags
     {
         PageFrameAllocation* alloc = allocation;
         while (alloc != 0) {
-            size += get_order_block_size(alloc->order);
+            size += get_frame_order_size(alloc->order);
             alloc = alloc->next;
         }
     }
@@ -281,7 +281,7 @@ VirtualAddress map_allocation(PageFrameAllocation* allocation, PagingFlags flags
     PageEntry* pt = get_or_alloc_page_entries(&pd[pt_index]);
 
     while (allocation != 0) {
-        uint64_t allocation_size = get_order_block_size(allocation->order);
+        uint64_t allocation_size = get_frame_order_size(allocation->order);
         uint64_t pages = allocation_size / PAGE_SIZE;
         map_range_helper(
             curr_virt_addr, allocation->addr, pages, flags, &pd_index, &pd, &pt_index, &pt);
@@ -404,14 +404,14 @@ void free_uefi_memory_and_remove_identity_mapping(void* uefi_memory_map) {
                     while (size != 0) {
                         uint8_t order = 0;
                         for (; order < FRAME_ORDERS; ++order) {
-                            const uint64_t order_size = get_order_block_size(order);
+                            const uint64_t order_size = get_frame_order_size(order);
                             if (order_size > size || (phys_addr % order_size) != 0) break;
                         }
                         --order;
 
                         KERNEL_ASSERT(order < FRAME_ORDERS, "Order does not exist")
 
-                        const uint64_t order_size = get_order_block_size(order);
+                        const uint64_t order_size = get_frame_order_size(order);
                         free_frames_contiguos(phys_addr, order_size / PAGE_SIZE);
                         size -= order_size;
                         phys_addr += order_size;


### PR DESCRIPTION
This PR allows users of the memory system to allocate pages without having to manually allocate frames which they then map.
This can be done with alloc_pages and free_pages for non physically contiguous pages and alloc_pages_contiguous and free_pages_contiguous for physically contiguous memory.

**IMPORTANT:** 
The interface pf alloc_frames_contiguous and free_frames_contiguous has also been changed to accept pages instead of orders.

Some other minor changes/fixes:
* Extracted types and defines out of memory.h and into memory/defs.h to avoid headers depending on each other.
* The unmap function previously used the get_or_alloc_page_entries function to traverse the page tables, but this would cause page table entries to be allocated when unmapping non mapped virtual memory.
* Added function get_min_size_frame_order which get the minimally sized order which fits the number of pages specified.
* Added unmap_and_free_frames which frees frames while unmapping memory.
* Renamed some functions to better reflect their purpose and make them more distinct.