### PR TITLE
Address spaces

### DIFF
--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -11,6 +11,37 @@
 
 typedef uint32_t PagingFlags;
 
+typedef union {
+    struct {
+        bool present : 1;
+        bool write : 1;
+        bool user : 1;
+        bool write_through : 1;
+        bool cache_disable : 1;
+        bool accessed : 1;
+        bool dirty : 1;
+        bool large : 1;
+        bool global : 1;
+        uint8_t ignored0 : 3;
+        PhysicalAddress phys_addr : 40;
+        uint8_t ignored1 : 7;
+        uint8_t prot : 4;
+        bool execute_disable : 1;
+    } __attribute__((packed));
+    uint64_t value;
+} PageEntry;
+
+typedef struct {
+    VirtualAddress next : 48;
+    VirtualAddress addr : 36;
+    uint64_t pages : 44;
+} __attribute__((packed)) FreeListEntry;
+
+typedef struct {
+    VirtualAddress next : 48;
+    VirtualAddress virt_addr : 36;
+    PhysicalAddress phys_addr : 38;
+} __attribute__((packed)) MappingEntry;
 // Maps discrete allocations into contiguos virtual address space
 VirtualAddress map_allocation(PageFrameAllocation* allocation, PagingFlags flags);
 

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -57,6 +57,18 @@ typedef struct {
     MappingEntry* entry_maps[2];
 } AddressSpace;
 
+// Fills in the AddressSpace struct, checks for sane values and allocates memory for PDP
+void new_address_space(AddressSpace* space, uint16_t pdp_index, uint8_t prot);
+
+// Frees page entries, lists and PDP
+void delete_address_space(AddressSpace* space);
+
+// Maps address space
+void map_address_space(AddressSpace* space);
+
+// Unmaps address space
+void unmap_address_space(AddressSpace* space);
+
 // Maps discrete allocations into contiguos virtual address space
 VirtualAddress map_allocation(AddressSpace* space, PageFrameAllocation* allocation,
                               PagingFlags flags);

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -42,6 +42,21 @@ typedef struct {
     VirtualAddress virt_addr : 36;
     PhysicalAddress phys_addr : 38;
 } __attribute__((packed)) MappingEntry;
+
+typedef struct {
+    VirtualAddress current_address;
+
+    uint16_t pdp_index;
+    PageEntry* pdp;
+
+    uint8_t prot : 4;
+
+    FreeListEntry* free_list;
+
+    // Holds physical to virtual mapping of page table entries
+    MappingEntry* entry_maps[2];
+} AddressSpace;
+
 // Maps discrete allocations into contiguos virtual address space
 VirtualAddress map_allocation(PageFrameAllocation* allocation, PagingFlags flags);
 

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -58,20 +58,32 @@ typedef struct {
 } AddressSpace;
 
 // Maps discrete allocations into contiguos virtual address space
-VirtualAddress map_allocation(PageFrameAllocation* allocation, PagingFlags flags);
+VirtualAddress map_allocation(AddressSpace* space, PageFrameAllocation* allocation,
+                              PagingFlags flags);
 
-// Maps the physical address range to available virtual address space
-VirtualAddress map_range(PhysicalAddress phys_addr, uint64_t pages, PagingFlags flags);
+// Maps the physical address range to available virtual address range
+VirtualAddress map_phys_range(AddressSpace* space, PhysicalAddress phys_addr, uint64_t pages,
+                              PagingFlags flags);
 
-// Unmaps virtual address space
-void unmap(VirtualAddress virt_addr, uint64_t pages);
+// Unmaps virtual address range
+void unmap_range(AddressSpace* space, VirtualAddress virt_addr, uint64_t pages);
 
 // Unmaps virtual address range and frees previously mapped frames
-void unmap_and_free_frames(VirtualAddress virt_addr, uint64_t pages);
+void unmap_and_free_frames(AddressSpace* space, VirtualAddress virt_addr, uint64_t pages);
 
 // Translates a virtual address into the corresponding physical address
 // Returns false if the virtual address isn't mapped
-bool get_physical_address(VirtualAddress virt_addr, PhysicalAddress* phys_addr);
+bool virt_to_phys_addr(AddressSpace* space, VirtualAddress virt_addr, PhysicalAddress* phys_addr);
+
+VirtualAddress kmap_allocation(PageFrameAllocation* allocation, PagingFlags flags);
+
+VirtualAddress kmap_phys_range(PhysicalAddress phys_addr, uint64_t pages, PagingFlags flags);
+
+void kunmap_range(VirtualAddress virt_addr, uint64_t pages);
+
+void kunmap_and_free_frames(VirtualAddress virt_addr, uint64_t pages);
+
+bool kvirt_to_phys_addr(VirtualAddress virt_addr, PhysicalAddress* phys_addr);
 
 void free_uefi_memory_and_remove_identity_mapping(void* uefi_memory_map);
 

--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -77,6 +77,11 @@ VirtualAddress map_allocation(AddressSpace* space, PageFrameAllocation* allocati
 VirtualAddress map_phys_range(AddressSpace* space, PhysicalAddress phys_addr, uint64_t pages,
                               PagingFlags flags);
 
+// Maps the physical address range to specified virtual address range if available
+// Returns false if address space isn't available or out of range
+bool map_to_range(AddressSpace* space, PhysicalAddress phys_addr, VirtualAddress virt_addr,
+                  uint64_t pages, PagingFlags flags);
+
 // Unmaps virtual address range
 void unmap_range(AddressSpace* space, VirtualAddress virt_addr, uint64_t pages);
 

--- a/kernel/src/acpi.c
+++ b/kernel/src/acpi.c
@@ -85,7 +85,7 @@ void prepare_acpi_memory(void* uefi_memory_map) {
         UEFIMemoryDescriptor* desc = (UEFIMemoryDescriptor*)&memory_map->buffer[i];
         if (desc->type != EfiACPIMemoryNVS && desc->type != EfiACPIReclaimMemory) continue;
 
-        const VirtualAddress virt = map_range(desc->physical_start, desc->num_pages, 0);
+        const VirtualAddress virt = kmap_phys_range(desc->physical_start, desc->num_pages, 0);
         ACPIMemRemap* entry = &g_remap_list[g_remap_count++];
 
         entry->phys = desc->physical_start;

--- a/kernel/src/apic.c
+++ b/kernel/src/apic.c
@@ -152,7 +152,7 @@ void setup_apic() {
                     ioapic->physical_address = (PhysicalAddress)entry->ioapic_address;
 
                     // Page each IOAPIC
-                    ioapic->virtual_address = (void*)map_range(
+                    ioapic->virtual_address = (void*)kmap_phys_range(
                         ioapic->physical_address, 1, PAGING_WRITABLE | PAGING_CACHE_DISABLE);
 
                     ioapic->used_irqs = 1 + read_ioapic_mre(ioapic->virtual_address);
@@ -209,8 +209,8 @@ void setup_apic() {
         }
 
         // Page Local APIC
-        g_lapic =
-            (LocalAPIC*)map_range(local_apic_phys_addr, 1, PAGING_WRITABLE | PAGING_CACHE_DISABLE);
+        g_lapic = (LocalAPIC*)kmap_phys_range(
+            local_apic_phys_addr, 1, PAGING_WRITABLE | PAGING_CACHE_DISABLE);
 
         // Set bit 8 of the Spurious Vector Register to enable the xAPIC
         // Using 0xFF as the Spurious Vector because osdev said so

--- a/kernel/src/memory.c
+++ b/kernel/src/memory.c
@@ -11,27 +11,27 @@ void* alloc_pages(uint64_t pages, PagingFlags paging_flags) {
     PageFrameAllocation* allocation = alloc_frames(pages);
     if (allocation == 0) return 0;
 
-    void* ptr = (void*)map_allocation(allocation, paging_flags);
+    void* ptr = (void*)kmap_allocation(allocation, paging_flags);
 
     free_frame_allocation_entries(allocation);
     return ptr;
 }
 
-void free_pages(void* ptr, uint64_t pages) { unmap_and_free_frames((VirtualAddress)ptr, pages); }
+void free_pages(void* ptr, uint64_t pages) { kunmap_and_free_frames((VirtualAddress)ptr, pages); }
 
 void* alloc_pages_contiguous(uint64_t pages, PagingFlags paging_flags) {
     PhysicalAddress phys_addr;
     if (!alloc_frames_contiguos(pages, &phys_addr)) return 0;
 
-    return (void*)map_range(phys_addr, pages, paging_flags);
+    return (void*)kmap_phys_range(phys_addr, pages, paging_flags);
 }
 
 void free_pages_contiguous(void* ptr, uint64_t pages) {
     PhysicalAddress phys_addr;
-    const bool success = get_physical_address((VirtualAddress)ptr, &phys_addr);
+    const bool success = kvirt_to_phys_addr((VirtualAddress)ptr, &phys_addr);
     KERNEL_ASSERT(success, "Physical address does not exist");
 
-    unmap((VirtualAddress)ptr, pages);
+    kunmap_range((VirtualAddress)ptr, pages);
     free_frames_contiguos(phys_addr, pages);
 }
 

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -104,7 +104,6 @@ extern char s_kernel_rodata_start;
 extern char s_kernel_rodata_end;
 extern char s_kernel_data_start;
 extern char s_kernel_data_end;
-extern char s_stack_top;
 
 PageEntry* get_page_entries(const PageEntry* entry, uint8_t level) {
     PhysicalAddress phys_addr = entry->phys_addr;

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -79,6 +79,7 @@ bool g_paging_execute_disable = false;
 struct {
     VirtualAddress current_address;
 
+    uint16_t pdp_index;
     PageEntry* pdp;
 
     FreeListEntry* free_list;
@@ -87,6 +88,7 @@ struct {
     MappingEntry* entry_maps[2];
 } g_kernel_map = {
     .current_address = KERNEL_OFFSET,
+    .pdp_index = KERNEL_PML4_OFFSET,
     .pdp = 0,
     .free_list = 0,
     .entry_maps = {0},

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -30,26 +30,6 @@
 #define GET_LEVEL_INDEX(addr, level) \
     (((addr) & (OFFSET_INDEX_MASK << (12 + 9 * (level)))) >> (12 + 9 * (level)))
 
-typedef union {
-    struct {
-        bool present : 1;
-        bool write : 1;
-        bool user : 1;
-        bool write_through : 1;
-        bool cache_disable : 1;
-        bool accessed : 1;
-        bool dirty : 1;
-        bool large : 1;
-        bool global : 1;
-        uint8_t ignored0 : 3;
-        PhysicalAddress phys_addr : 40;
-        uint8_t ignored1 : 7;
-        uint8_t prot : 4;
-        bool execute_disable : 1;
-    } __attribute__((packed));
-    uint64_t value;
-} PageEntry;
-
 typedef struct {
     uint16_t pd_index;
     PageEntry* pd;
@@ -57,18 +37,6 @@ typedef struct {
     uint16_t pt_index;
     PageEntry* pt;
 } PageTableLocation;
-
-typedef struct {
-    VirtualAddress next : 48;
-    VirtualAddress addr : 36;
-    uint64_t pages : 44;
-} __attribute__((packed)) FreeListEntry;
-
-typedef struct {
-    VirtualAddress next : 48;
-    VirtualAddress virt_addr : 36;
-    PhysicalAddress phys_addr : 38;
-} __attribute__((packed)) MappingEntry;
 
 typedef MappingEntry PagePoolEntry;
 

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -44,20 +44,11 @@ PageEntry __attribute__((aligned(0x1000))) g_pml4[512] = {0};
 
 bool g_paging_execute_disable = false;
 
-struct {
-    VirtualAddress current_address;
-
-    uint16_t pdp_index;
-    PageEntry* pdp;
-
-    FreeListEntry* free_list;
-
-    // Holds physical to virtual mapping of page table entries
-    MappingEntry* entry_maps[2];
-} g_kernel_map = {
+AddressSpace g_kernel_map = {
     .current_address = KERNEL_OFFSET,
     .pdp_index = KERNEL_PML4_OFFSET,
     .pdp = 0,
+    .prot = 0,
     .free_list = 0,
     .entry_maps = {0},
 };

--- a/kernel/src/pci.c
+++ b/kernel/src/pci.c
@@ -68,19 +68,19 @@ void enumerate_pci_devices() {
                     PhysicalAddress config_phys_addr =
                         base_phys_addr + ((bus << 20) | (device << 15) | (func << 12));
 
-                    const PCIConfigSpace0* config_space = (const PCIConfigSpace0*)map_range(
+                    const PCIConfigSpace0* config_space = (const PCIConfigSpace0*)kmap_phys_range(
                         config_phys_addr, 1, PAGING_WRITABLE | PAGING_CACHE_DISABLE);
 
                     const bool exists = config_space->vendor_id != 0xffff;
                     const bool is_multi_func = (config_space->header_type & 0x80) != 0;
 
                     if (func > 0 && !is_multi_func) {
-                        unmap((VirtualAddress)config_space, 1);
+                        kunmap_range((VirtualAddress)config_space, 1);
                         break;
                     }
 
                     if (!exists) {
-                        unmap((VirtualAddress)config_space, 1);
+                        kunmap_range((VirtualAddress)config_space, 1);
                         continue;
                     }
 

--- a/kernel/src/rendering.c
+++ b/kernel/src/rendering.c
@@ -14,9 +14,9 @@ void remap_framebuffer() {
 
     const uint64_t framebuffer_pages = framebuffer_size / PAGE_SIZE;
 
-    g_frame_buffer.address = (void*)map_range((PhysicalAddress)g_frame_buffer.address,
-                                              framebuffer_pages,
-                                              PAGING_WRITABLE | PAGING_CACHE_DISABLE);
+    g_frame_buffer.address = (void*)kmap_phys_range((PhysicalAddress)g_frame_buffer.address,
+                                                    framebuffer_pages,
+                                                    PAGING_WRITABLE | PAGING_CACHE_DISABLE);
 }
 
 void put_pixel(uint64_t x, uint64_t y, uint32_t color) {


### PR DESCRIPTION
This PR adds the ability to create new address spaces, this feature will mainly be used in creating address spaces for userspace.

New address spaces can be created using new_address_space, and then mapped using map_address_space. The old paging functions can be used to manage this address space. New kernel variants of the paging functions have been added to manage kernel address space. 

The function map_to_range was also added which allows you to map a physical address range to a specific virtual address range if said range is available and not out of range for the address space.

Some slight optimizations were also done:
* Split the mapping entry list in two, one for PTs and one for PDs. This should reduce lookup time a bit.
* The page pool code was simplified a bit and entries are now only added to the mapping list when they are being used.
