### PR TITLE
Interrupts improvement

### DIFF
--- a/kernel/include/idt.h
+++ b/kernel/include/idt.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 #define INTERRUPT_GATE 14
 #define TRAP_GATE 15
@@ -22,5 +23,6 @@ typedef struct {
 
 void setup_idt();
 
-void register_interrupt(uint8_t irq, uint8_t type, uint64_t handler_address);
+// Registers interrupt
+void register_interrupt(uint8_t irq, uint8_t type, bool ist, void* handler);
 

--- a/kernel/include/idt.h
+++ b/kernel/include/idt.h
@@ -26,3 +26,5 @@ void setup_idt();
 // Registers interrupt
 void register_interrupt(uint8_t irq, uint8_t type, bool ist, void* handler);
 
+// Unregisters interrupt
+void unregister_interrupt(uint8_t irq);

--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -40,20 +40,10 @@ struct {
 struct {
     uint32_t reserved0;
     // Stack pointers for different privilege levels
-    uint64_t rsp0;
-    uint64_t rsp1;
-    uint64_t rsp2;
+    void* rsp[3];
     uint64_t reserved1;
-    // Interrupt stack table
-    uint64_t ist1;
-    uint64_t ist2;
-    uint64_t ist3;
-    uint64_t ist4;
-    uint64_t ist5;
-    uint64_t ist6;
-    uint64_t ist7;
-    uint64_t reserved2;
-    uint16_t reserved3;
+    void* interrupt_stack_table[7];
+    uint8_t reserved2[10];
     // IO bitmap
     uint16_t iopb_offset;
 } __attribute__((packed)) g_tss = {0};

--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -20,7 +20,7 @@ struct {
     GDTEntry user_data;
     GDTEntry tss_low;
     GDTEntry tss_high;
-} __attribute__((packed)) g_gdt = {
+} __attribute__((packed)) __attribute__((aligned(8))) g_gdt = {
     // https://wiki.osdev.org/Global_Descriptor_Table
     // Null segments are required
     .null = {0, 0, 0, 0, 0, 0},
@@ -46,7 +46,7 @@ struct {
     uint8_t reserved2[10];
     // IO bitmap
     uint16_t iopb_offset;
-} __attribute__((packed)) g_tss = {0};
+} __attribute__((packed)) __attribute__((aligned(8))) g_tss = {0};
 
 __attribute__((naked)) void set_gdt_and_tss(void* __attribute__((unused)) gdt) {
     // Translate C defines into assembly "defines"

--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -58,48 +58,43 @@ struct {
     uint16_t iopb_offset;
 } __attribute__((packed)) g_tss = {0};
 
-// Setup defines in assembly
-// Weird C nested macros are required here to concatenate
-// the inline assembly strings with the value of the macro as a string
+__attribute__((naked)) void set_gdt_and_tss(void* __attribute__((unused)) gdt) {
+    // Translate C defines into assembly "defines"
 #define STR(x) #x
 #define XSTR(s) STR(s)
-asm(".equ KERNEL_CODE_SEGMENT, " XSTR(GDT_KERNEL_CODE_SEGMENT) "\n");
-asm(".equ KERNEL_DATA_SEGMENT, " XSTR(GDT_KERNEL_DATA_SEGMENT) "\n");
-asm(".equ TSS_SEGMENT, " XSTR(GDT_TSS_SEGMENT) "\n");
+    asm(".equ KERNEL_CODE_SEGMENT, " XSTR(GDT_KERNEL_CODE_SEGMENT) "\n");
+    asm(".equ KERNEL_DATA_SEGMENT, " XSTR(GDT_KERNEL_DATA_SEGMENT) "\n");
+    asm(".equ TSS_SEGMENT, " XSTR(GDT_TSS_SEGMENT) "\n");
 #undef XSTR
 #undef STR
 
-// Define the function set_gdt in assembly
-asm("set_gdt_and_tss:\n"
+    asm(
+        // Disable interrupts before setting GDT and TSS
+        "cli\n"
 
-    // Disable interrupts before setting GDT and TSS
-    "cli\n"
+        // Set pointer to GDT
+        "lgdt (%rdi)\n"
 
-    // Set pointer to GDT
-    "lgdt (%rdi)\n"
+        // Setup offset to TSS
+        "mov $TSS_SEGMENT, %ax\n"
+        "ltr %ax\n"
 
-    // Setup offset to TSS
-    "mov $TSS_SEGMENT, %ax\n"
-    "ltr %ax\n"
+        // Set all segment registers to the kernel data segment
+        "mov $KERNEL_DATA_SEGMENT, %ax\n"
+        "mov %ax, %ds\n"
+        "mov %ax, %es\n"
+        "mov %ax, %fs\n"
+        "mov %ax, %gs\n"
+        "mov %ax, %ss\n"
 
-    // Set all segment registers to the kernel data segment
-    "mov $KERNEL_DATA_SEGMENT, %ax\n"
-    "mov %ax, %ds\n"
-    "mov %ax, %es\n"
-    "mov %ax, %fs\n"
-    "mov %ax, %gs\n"
-    "mov %ax, %ss\n"
-
-    // Push code segment onto stack before return address to use far return
-    // this sets the code segment register (cs)
-    "pop %rdi\n"
-    "mov $KERNEL_CODE_SEGMENT, %rax\n"
-    "push %rax\n"
-    "push %rdi\n"
-    "lretq\n");
-
-// This is the function defined in assembly
-extern void set_gdt_and_tss(void* gdt);
+        // Push code segment onto stack before return address to use far return
+        // this sets the code segment register (cs)
+        "pop %rdi\n"
+        "mov $KERNEL_CODE_SEGMENT, %rax\n"
+        "push %rax\n"
+        "push %rdi\n"
+        "lretq\n");
+}
 
 void setup_gdt_and_tss() {
     // Set io bitmap offset to the size of the TSS because we are not using it.
@@ -121,16 +116,13 @@ void setup_gdt_and_tss() {
     // We will give a pointer to this struct to the lgdt instruction
     struct {
         uint16_t size;
-        uint64_t base;
+        void* base;
     } __attribute__((packed)) gdt;
 
-    // TODO(Anton Lilja, 10-04-21):
-    // We have to do manual assignment here because the compiler might try to optimize in virtual
-    // address pointers at compile time otherwise.
-    // Find way to disable this optimization or
-    // make sure to map kernel correctly before any of this code.
+    // NOTE (Anton Lilja, 12/05/2021):
+    // For some reason we can't assign directly to the struct, it refuses to load the GDT if we do.
     gdt.size = sizeof(g_gdt) - 1;
-    gdt.base = (uint64_t)&g_gdt;
+    gdt.base = (void*)&g_gdt;
 
     set_gdt_and_tss((void*)&gdt);
 }

--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -1,6 +1,10 @@
 #include "gdt.h"
 #include <stdint.h>
 
+#include "memory.h"
+
+#define TSS_STACK_PAGES 2
+
 // https://wiki.osdev.org/Global_Descriptor_Table
 typedef struct {
     uint16_t limit_0_15;
@@ -90,8 +94,11 @@ void setup_gdt_and_tss() {
     // Set io bitmap offset to the size of the TSS because we are not using it.
     g_tss.iopb_offset = sizeof(g_tss);
 
-    // TODO (Anton Lilja, 29-03-2021):
-    // Setup TSS properly with an interrupt stack table and privilege level stack pointers.
+    // Allocate privilege level 0 stack
+    g_tss.rsp[0] = (void*)alloc_pages(TSS_STACK_PAGES, PAGING_WRITABLE);
+
+    // Allocate one entry of the interrupt descriptor table
+    g_tss.interrupt_stack_table[0] = (void*)alloc_pages(TSS_STACK_PAGES, PAGING_WRITABLE);
 
     // Setup GDT entry for the TSS
     // The address is split up into several fields

--- a/kernel/src/idt.c
+++ b/kernel/src/idt.c
@@ -2,6 +2,7 @@
 #include "gdt.h"
 
 #include <stdint.h>
+#include <string.h>
 
 // https://wiki.osdev.org/Interrupt_Descriptor_Table#IDT_in_IA-32e_Mode_.2864-bit_IDT.29
 typedef struct {
@@ -56,3 +57,5 @@ void set_idt_gate(uint8_t irq, uint8_t type, uint64_t handler_address, uint16_t 
 void register_interrupt(uint8_t irq, uint8_t type, bool ist, void* handler) {
     set_idt_gate(irq, type, (uint64_t)handler, GDT_KERNEL_CODE_SEGMENT, 0, ist ? 1 : 0);
 }
+
+void unregister_interrupt(uint8_t irq) { memset((void*)&g_idt[irq], 0, sizeof(IDTEntry)); }

--- a/kernel/src/idt.c
+++ b/kernel/src/idt.c
@@ -43,8 +43,6 @@ void setup_idt() {
 }
 
 // General way to register an interrupt where you can set all values
-// This is not in the header because it doesn't make sense to specify an
-// IST, segment selector or the privilege level
 void set_idt_gate(uint8_t irq, uint8_t type, uint64_t handler_address, uint16_t segment_selector,
                   uint8_t ist, uint8_t privilege) {
     g_idt[irq].offset_0_15 = handler_address & 0xffff;
@@ -55,10 +53,6 @@ void set_idt_gate(uint8_t irq, uint8_t type, uint64_t handler_address, uint16_t 
     g_idt[irq].offset_32_63 = (handler_address >> 32) & 0xffffffff;
 }
 
-// Convenience function to register interrupts for the kernel without an ist
-// TODO (Anton Lilja, 30-03-2021):
-// This might be a temporary interface to register interrupts,
-// we need the specify ist for certain interrupts where a new stack is needed.
-void register_interrupt(uint8_t irq, uint8_t type, uint64_t handler_address) {
-    set_idt_gate(irq, type, handler_address, GDT_KERNEL_CODE_SEGMENT, 0, 0);
+void register_interrupt(uint8_t irq, uint8_t type, bool ist, void* handler) {
+    set_idt_gate(irq, type, (uint64_t)handler, GDT_KERNEL_CODE_SEGMENT, 0, ist ? 1 : 0);
 }


### PR DESCRIPTION
* General cleanup of gdt.c and idt.c.
* Made GDT and TSS 8 byte aligned per the intel x64 spec.
* Sets up up privilege level stacks and one interrupt stack table entry. 
* The interrupt interface was changed to make it easier to use and differentiate between interrupts and exceptions/faults. 
* unregister_interrupt function was added.