### PR TITLE
Add pagefault interrupts

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/acpi.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pci.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/apic.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/exceptions.c
+  
 
   # Memory
   ${CMAKE_CURRENT_SOURCE_DIR}/src/memory.c

--- a/kernel/include/exceptions.h
+++ b/kernel/include/exceptions.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Registers processor exception/fault interrupts (idt 0 to 0x20)
+void register_exception_interrupts();

--- a/kernel/include/idt.h
+++ b/kernel/include/idt.h
@@ -21,6 +21,15 @@ typedef struct {
     uint64_t ss;
 } __attribute__((packed)) InterruptFrame;
 
+typedef struct {
+    uint64_t err;
+    uint64_t rip;
+    uint64_t cs;
+    uint64_t flags;
+    uint64_t rsp;
+    uint64_t ss;
+} __attribute__((packed)) ErrorCodeInterruptFrame;
+
 void setup_idt();
 
 // Registers interrupt

--- a/kernel/src/exceptions.c
+++ b/kernel/src/exceptions.c
@@ -1,0 +1,63 @@
+// https://wiki.osdev.org/Exceptions
+#include "exceptions.h"
+
+#include "idt.h"
+#include "rendering.h"
+
+#define DIV_BY_ZERO 0
+#define DEBUG 1
+#define NON_MASKABLE_INTERRUPT 2
+#define BREAKPOINT 3
+#define OVERFLOW 4
+#define BOUND_RANGE_EXCEEDED 5
+#define INVALID_OPCODE 6
+#define DEVICE_NOT_AVAILABLE 7
+#define DOUBLE_FAULT 8
+#define INVALID_TSS 10
+#define SEGMENT_NOT_PRESENT 11
+#define STACK_SEGMENTATION_FAULT 12
+#define GENERAL_PROTECTION_FAULT 13
+#define PAGE_FAULT 14
+#define FLOAT_EXCEPTION 16
+#define ALIGNMENT_CHECK 17
+#define MACHINE_CHECK 18
+#define SIMD_FLOAT_EXCEPTION 19
+
+__attribute__((interrupt)) void page_fault(ErrorCodeInterruptFrame* frame) {
+    clear_screen(0);
+    uint64_t x = 10;
+    uint64_t y = 10;
+
+    g_fg_color = 0xff0000;
+    put_string("PAGE FAULT", x, y);
+
+    x += put_string("Instruction   (RIP): ", x, ++y);
+    x += put_hex(frame->rip, x, y);
+    x = 10;
+
+    x += put_string("Stack pointer (RSP): ", x, ++y);
+    x += put_hex(frame->rsp, x, y);
+    x = 10;
+
+    // CR2 contains the address read that cause the exception
+    uint64_t cr2;
+    asm volatile("mov %%cr2, %0" : "=r"(cr2));
+
+    x += put_string("Page fault address: ", x, ++y);
+    x += put_hex(cr2, x, y);
+    x = 10;
+    y++;
+
+    // Error codes are found in https://wiki.osdev.org/Exceptions#Page_Fault
+    put_string("Page fault info: ", x, ++y);
+    put_string((frame->err & 1) ? "page-protection violation" : "non-present page", x, ++y);
+    put_string((frame->err & 2) ? "while writing" : "while reading", x, ++y);
+    put_string((frame->err & 16) ? "during an instruction fetch" : "", x, ++y);
+
+    while (1)
+        ;
+}
+
+void register_exception_interrupts() {
+    register_interrupt(PAGE_FAULT, INTERRUPT_GATE, false, (void*)&page_fault);
+}

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -6,6 +6,7 @@
 #include "acpi.h"
 #include "pci.h"
 #include "apic.h"
+#include "exceptions.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -74,19 +75,22 @@ _Noreturn void kernel_entry(void* mm, void* fb, PhysicalAddress rsdp) {
     setup_idt();
     put_string("Interrupt descriptor table initalized", 10, 14);
 
+    register_exception_interrupts();
+    put_string("Registered exception interrupts", 10, 15);
+
     // After this point all physical addresses have to be mapped to virtual memory
     // NOTE: The memory pointed at by mm and fb should NOT be used after this point
     free_uefi_memory_and_remove_identity_mapping(mm);
-    put_string("UEFI data deallocated and identity mapping removed", 10, 15);
+    put_string("UEFI data deallocated and identity mapping removed", 10, 16);
 
     initialize_acpi(rsdp);
-    put_string("ACPI Initialized", 10, 16);
+    put_string("ACPI Initialized", 10, 17);
 
     enumerate_pci_devices();
-    put_string("PCI devices enumerated", 10, 17);
+    put_string("PCI devices enumerated", 10, 18);
 
     setup_apic();
-    put_string("APIC(s) set up and usable", 10, 18);
+    put_string("APIC(s) set up and usable", 10, 19);
 
     // This function can't return
     while (1)


### PR DESCRIPTION
https://wiki.osdev.org/Exceptions#Page_Fault

## Add interrupt frame with error 

Some exceptions have an additonal error uint64_t pushed on the stack. And we need those.

## Added page fault interrupt handler

Pagefaults have to be added to the idt in register_exception_interrupts.