### PR TITLE
Process system

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(kernel
   ${CMAKE_CURRENT_SOURCE_DIR}/src/exceptions.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/syscalls.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/elf_loader.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/process_system.c
 
   # Memory
   ${CMAKE_CURRENT_SOURCE_DIR}/src/memory.c

--- a/kernel/include/gdt.h
+++ b/kernel/include/gdt.h
@@ -7,4 +7,6 @@
 
 #define GDT_TSS_SEGMENT 0x30
 
+void set_tss_kernel_stack(void* stack_ptr);
+
 void setup_gdt_and_tss();

--- a/kernel/include/process_system.h
+++ b/kernel/include/process_system.h
@@ -6,4 +6,8 @@
 AddressSpace* get_current_process_addr_space();
 uint64_t get_current_process_pid();
 
+// Starts a user process
+// NOTE: This function should only be called when at least one process is already running
+void start_user_process(const void* elf_data);
+
 void initialize_process_system();

--- a/kernel/include/process_system.h
+++ b/kernel/include/process_system.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "memory/paging.h"
+
+#include <stdint.h>
+
+AddressSpace* get_current_process_addr_space();
+uint64_t get_current_process_pid();

--- a/kernel/include/process_system.h
+++ b/kernel/include/process_system.h
@@ -5,3 +5,5 @@
 
 AddressSpace* get_current_process_addr_space();
 uint64_t get_current_process_pid();
+
+void initialize_process_system();

--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -85,13 +85,11 @@ __attribute__((naked)) void set_gdt_and_tss(void* __attribute__((unused)) gdt) {
           [tss_segment] "i"(GDT_TSS_SEGMENT));
 }
 
+void set_tss_kernel_stack(void* stack_ptr) { g_tss.rsp[0] = stack_ptr; }
+
 void setup_gdt_and_tss() {
     // Set io bitmap offset to the size of the TSS because we are not using it.
     g_tss.iopb_offset = sizeof(g_tss);
-
-    // Allocate privilege level 0 stack
-    g_tss.rsp[0] =
-        (void*)alloc_pages(TSS_STACK_PAGES, PAGING_WRITABLE) + TSS_STACK_PAGES * PAGE_SIZE;
 
     // Allocate one entry of the interrupt descriptor table
     g_tss.interrupt_stack_table[0] =

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -8,6 +8,7 @@
 #include "apic.h"
 #include "exceptions.h"
 #include "syscalls.h"
+#include "process_system.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -95,6 +96,9 @@ _Noreturn void kernel_entry(void* mm, void* fb, PhysicalAddress rsdp) {
 
     prepare_syscalls();
     put_string("Syscalls enabled", 10, 20);
+
+    initialize_process_system();
+    put_string("Process system initialized", 10, 21);
 
     // This function can't return
     while (1)

--- a/kernel/src/process_system.c
+++ b/kernel/src/process_system.c
@@ -1,8 +1,18 @@
 #include "process_system.h"
 
+#include "idt.h"
+#include "apic.h"
 #include "memory.h"
 
 #include <string.h>
+
+// APIC timer defines
+#define APIC_TIMER_IRQ_MASK 0xff
+#define APIC_TIMER_MASKED_MASK (1 << 16)
+#define APIC_TIMER_MODE_MASK (0b11 << 17)
+#define APIC_TIMER_PERIODIC_MODE (0b1 << 17)
+#define APIC_TIMER_IRQ 32
+#define APIC_TIMER_INITIAL_COUNT 0xffffff
 
 // Stores process information
 // All registers except rsp are stored on the user stack when process is not running
@@ -25,6 +35,177 @@ _Static_assert(sizeof(g_process_queue) == 16, "Size of g_process_queue is not 16
 __attribute__((always_inline)) uint64_t generate_pid() {
     static uint64_t pid = 0;
     return pid++;
+}
+
+__attribute__((naked)) void context_switch_handler() {
+    asm volatile(
+        // Save rax on stack
+        "push %rax\n"
+        "push %rbx\n"
+
+        // Put g_process_queue ptr in rax
+        "lea g_process_queue(%rip), %rax\n"
+
+        // Check if tail ptr is zero (This means there is only one process)
+        "mov 0x8(%rax), %rbx\n"
+        "cmpq $0x0, %rbx\n"
+        "jnz __switch_process\n"
+
+        // We only have to send an EOI because we're jumping back to the same process
+
+        // Send EOI to local APIC
+        "lea g_lapic(%rip), %rax\n"
+        "mov (%rax), %rax\n"
+        "movl $0x0, 0xb0(%rax)\n"
+        "pop %rbx\n"
+        "pop %rax\n"
+
+        "iretq\n"
+
+        // We are switching to a new process
+        "__switch_process:\n"
+
+        // Save interrupt stack ptr in rbx
+        "mov %rsp, %rbx\n"
+
+        // Switch over to process stack to save registers onto
+        "mov 0x28(%rbx), %rsp\n"
+
+        // Save rip
+        "mov 0x10(%rbx), %rax\n"
+        "push %rax\n"
+
+        // Save cs
+        "mov 0x18(%rbx), %rax\n"
+        "push %rax\n"
+
+        // Save rflags
+        "mov 0x20(%rbx), %rax\n"
+        "push %rax\n"
+
+        // Save ss
+        "mov 0x30(%rbx), %rax\n"
+        "push %rax\n"
+
+        // Save rbp
+        "push %rbp\n"
+
+        // Save rax
+        "mov 0x8(%rbx), %rax\n"
+        "push %rax\n"
+
+        // Save rbx
+        "mov (%rbx), %rax\n"
+        "push %rax\n"
+
+        // Save general purpose registers
+        "push %rcx\n"
+        "push %rdx\n"
+        "push %rsi\n"
+        "push %rdi\n"
+        "push %r8\n"
+        "push %r9\n"
+        "push %r10\n"
+        "push %r11\n"
+        "push %r12\n"
+        "push %r13\n"
+        "push %r14\n"
+        "push %r15\n"
+
+        // Save process kernel stack ptr
+        "lea g_tss(%rip), %rax\n"
+        "mov 0x4(%rax), %rcx\n"
+        "push %rcx\n"
+
+        // Put head ptr into rax
+        "lea g_process_queue(%rip), %rax\n"
+        "mov (%rax), %rax\n"
+
+        // Save current process rsp
+        "mov %rsp, 0x18(%rax)\n"
+
+        // Restore interrupt stack ptr
+        "mov %rbx, %rsp\n"
+
+        // Unmap address space of old process
+        "mov 0x8(%rax), %rdi\n"
+        "call unmap_address_space\n"
+
+        // Put head at back of queue
+        // pop_from_queue returns the new head ptr (in rax)
+        "call pop_from_queue\n"
+
+        // Map address space of new process
+        "mov 0x8(%rax), %rdi\n"
+        "call map_address_space\n"
+
+        // Save interrupt stack ptr to rbx
+        "mov %rsp, %rbx\n"
+
+        // Set rsp to user stack ptr to restore registers
+        "mov 0x18(%rax), %rsp\n"
+
+        // Replace old process kernel stack ptr with new process kernel stack ptr
+        "pop %rcx\n"
+        "lea g_tss(%rip), %rdx\n"
+        "mov %rcx, 0x4(%rdx)\n"
+
+        // Restore general purpose registers
+        "pop %r15\n"
+        "pop %r14\n"
+        "pop %r13\n"
+        "pop %r12\n"
+        "pop %r11\n"
+        "pop %r10\n"
+        "pop %r9\n"
+        "pop %r8\n"
+        "pop %rdi\n"
+        "pop %rsi\n"
+        "pop %rdx\n"
+        "pop %rcx\n"
+
+        // Pop rbx and replace old rbx on kernel stack
+        "pop %rax\n"
+        "mov %rax, (%rbx)\n"
+
+        // Pop rax and replace old rax on kernel stack
+        "pop %rax\n"
+        "mov %rax, 0x8(%rbx)\n"
+
+        "pop %rbp\n"
+
+        // Pop ss and replace old ss on kernel stack
+        "pop %rax\n"
+        "mov %rax, 0x30(%rbx)\n"
+
+        // Pop rflags and replace old rflags on kernel stack
+        "pop %rax\n"
+        "mov %rax, 0x20(%rbx)\n"
+
+        // Pop cs and replace cs on kernel stack
+        "pop %rax\n"
+        "mov %rax, 0x18(%rbx)\n"
+
+        // Pop rip and replace old rip on kernel stack
+        "pop %rax\n"
+        "mov %rax, 0x10(%rbx)\n"
+
+        // Restore interrupt stack ptr
+        "mov %rbx, %rsp\n"
+
+        // Restore rbx
+        "pop %rbx\n"
+
+        // Send EOI to local APIC
+        "lea g_lapic(%rip), %rax\n"
+        "mov (%rax), %rax\n"
+        "movl $0x0, 0xb0(%rax)\n"
+
+        // Restore rax
+        "pop %rax\n"
+
+        // Return from interrupt
+        "iretq\n");
 }
 
 AddressSpace* get_current_process_addr_space() { return g_process_queue.head->addr_space; }
@@ -55,4 +236,27 @@ Process* alloc_process_and_addr_space(uint8_t paging_prot) {
     new_address_space(process->addr_space, 0, paging_prot);
 
     return process;
+}
+
+void initialize_process_system() {
+    // Initialize local APIC timer
+    register_interrupt(APIC_TIMER_IRQ, INTERRUPT_GATE, false, (void*)&context_switch_handler);
+
+    // Set mode to periodic mode
+    g_lapic->lvt_timer &= ~APIC_TIMER_MODE_MASK;
+    g_lapic->lvt_timer |= APIC_TIMER_PERIODIC_MODE;
+
+    // Set irq
+    g_lapic->lvt_timer &= ~APIC_TIMER_IRQ_MASK;
+    g_lapic->lvt_timer |= APIC_TIMER_IRQ;
+
+    // Mask LINT0 and LINT1 interrupts
+    g_lapic->lvt_lint0 |= APIC_TIMER_MODE_MASK;
+    g_lapic->lvt_lint1 |= APIC_TIMER_MODE_MASK;
+
+    // Set divice config to 2
+    g_lapic->divide_configuration = 0x0;
+
+    // Unmask timer interrupt
+    g_lapic->lvt_timer &= ~APIC_TIMER_MASKED_MASK;
 }

--- a/kernel/src/process_system.c
+++ b/kernel/src/process_system.c
@@ -1,0 +1,58 @@
+#include "process_system.h"
+
+#include "memory.h"
+
+#include <string.h>
+
+// Stores process information
+// All registers except rsp are stored on the user stack when process is not running
+typedef struct {
+    void* next;               // 0x00
+    AddressSpace* addr_space; // 0x8
+    uint64_t pid;             // 0x10
+    void* rsp;                // 0x18
+} __attribute__((packed)) Process;
+
+_Static_assert(sizeof(Process) == 32, "Size of Process struct is not 32 bytes");
+
+struct {
+    Process* head; // 0x0
+    Process* tail; // 0x8
+} __attribute__((packed)) g_process_queue = {0};
+
+_Static_assert(sizeof(g_process_queue) == 16, "Size of g_process_queue is not 16 bytes");
+
+__attribute__((always_inline)) uint64_t generate_pid() {
+    static uint64_t pid = 0;
+    return pid++;
+}
+
+AddressSpace* get_current_process_addr_space() { return g_process_queue.head->addr_space; }
+uint64_t get_current_process_pid() { return g_process_queue.head->pid; }
+
+Process* pop_from_queue() {
+    if (g_process_queue.tail == 0) return 0;
+
+    Process* head = g_process_queue.head;
+    g_process_queue.head = head->next;
+    head->next = 0;
+    g_process_queue.tail->next = head;
+    g_process_queue.tail = head;
+
+    return g_process_queue.head;
+}
+
+Process* alloc_process_and_addr_space(uint8_t paging_prot) {
+    // Allocate Process struct
+    Process* process = kalloc(sizeof(Process));
+    memset(process, 0, sizeof(Process));
+
+    // Allocate AddressSpace struct
+    process->addr_space = kalloc(sizeof(AddressSpace));
+    memset(process->addr_space, 0, sizeof(AddressSpace));
+
+    // Create new address space
+    new_address_space(process->addr_space, 0, paging_prot);
+
+    return process;
+}


### PR DESCRIPTION
This PR adds a process system which can run userspace processes and switch between them through the local APIC timer.

Functionality of context switch handler:
If there is more than one process it pushes all registers, the rflags and the process kernel stack ptr onto the process stack.
The process address space is unmapped and the process is put at the back of the queue. The address space of the new process is mapped and the process stack is switch so that all registers, the rflags and the kernel stack can be restored. 
Before all return points an EOI is sent to the local APIC.

The last block of  the initialize_process_system is disabled because we don't have any good way of loading ELF binaries as of now. The code can be tested by providing you own header which contains an array of an ELF binaries bytes.