### PR TITLE
Final paging improvements and bug fixes

### DIFF
--- a/kernel/include/memory/paging.h
+++ b/kernel/include/memory/paging.h
@@ -97,6 +97,11 @@ void unmap_and_free_frames(AddressSpace* space, VirtualAddress virt_addr, uint64
 // Returns false if the virtual address isn't mapped
 bool virt_to_phys_addr(AddressSpace* space, VirtualAddress virt_addr, PhysicalAddress* phys_addr);
 
+// Sets the flags for a virtual address range
+// Returns false if range is not mapped
+bool range_set_flags(AddressSpace* space, VirtualAddress virt_addr, uint64_t pages,
+                     PagingFlags flags);
+
 VirtualAddress kmap_allocation(PageFrameAllocation* allocation, PagingFlags flags);
 
 VirtualAddress kmap_phys_range(PhysicalAddress phys_addr, uint64_t pages, PagingFlags flags);

--- a/kernel/src/exceptions.c
+++ b/kernel/src/exceptions.c
@@ -100,6 +100,8 @@ __attribute__((interrupt)) void page_fault(ErrorCodeInterruptFrame* frame) {
     put_string("Page fault info: ", x, ++y);
     put_string((frame->err & 1) ? "page-protection violation" : "non-present page", x, ++y);
     put_string((frame->err & 2) ? "while writing" : "while reading", x, ++y);
+    if ((frame->err & 4) != 0) put_string("user bit", x, ++y);
+    if ((frame->err & 8) != 0) put_string("reserved bit", x, ++y);
     put_string((frame->err & 16) ? "during an instruction fetch" : "", x, ++y);
 
     while (1)

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -70,6 +70,8 @@ void new_address_space(AddressSpace* space, uint16_t pdp_index, uint8_t prot) {
     KERNEL_ASSERT(pdp_index < KERNEL_PML4_OFFSET,
                   "AddressSpace can't overlap with kernel address space")
 
+    memset(space, 0, sizeof(AddressSpace));
+
     KERNEL_ASSERT(prot <= 0b1111, "Prot is only 4 bits page entries")
     space->prot = prot;
 

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -290,7 +290,7 @@ VirtualAddress alloc_addr_space(AddressSpace* space, uint64_t pages) {
             }
 
             last = entry;
-            entry = (FreeListEntry*)entry->next;
+            entry = (FreeListEntry*)SIGN_EXT_ADDR(entry->next);
         }
     }
 

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -530,6 +530,26 @@ bool virt_to_phys_addr(AddressSpace* space, VirtualAddress virt_addr, PhysicalAd
     return true;
 }
 
+bool range_set_flags(AddressSpace* space, VirtualAddress virt_addr, uint64_t pages,
+                     PagingFlags flags) {
+    PageTableLocation location;
+    populate_page_table_location(space, virt_addr, &location, false);
+
+    for (uint64_t i = 0; i < pages; ++i) {
+        page_table_traversal_helper(space, virt_addr, &location, false);
+
+        const uint16_t index = GET_LEVEL_INDEX(virt_addr, PT);
+
+        if (location.pt[index].present == false) return false;
+
+        set_flags(&location.pt[index], flags);
+
+        virt_addr += PAGE_SIZE;
+    }
+
+    return true;
+}
+
 VirtualAddress kmap_allocation(PageFrameAllocation* allocation, PagingFlags flags) {
     return map_allocation(&g_kernel_space, allocation, flags);
 }

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -675,6 +675,7 @@ VirtualAddress initialize_paging(void* uefi_memory_map, PhysicalAddress kernel_p
 
     g_kernel_space.pdp = (PageEntry*)allocated_phys_addr;
     allocated_phys_addr += PAGE_SIZE;
+    memset(g_kernel_space.pdp, 0, PAGE_SIZE);
 
     g_pml4[KERNEL_PML4_OFFSET].phys_addr = (PhysicalAddress)g_kernel_space.pdp >> 12;
     g_pml4[KERNEL_PML4_OFFSET].present = true;

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -22,6 +22,8 @@
 
 #define OFFSET_INDEX_MASK 0x1ffULL
 
+#define NON_EXT_ADDR_MASK 0xffffffffffffULL
+
 #define PT 0
 #define PD 1
 #define PDP 2
@@ -374,7 +376,7 @@ VirtualAddress map_phys_range(AddressSpace* space, PhysicalAddress phys_addr, ui
 }
 
 bool claim_virt_range(AddressSpace* space, VirtualAddress virt_addr, uint64_t pages) {
-    if (space->current_address <= virt_addr) {
+    if (space->current_address <= (virt_addr & NON_EXT_ADDR_MASK)) {
         // Check if virtual address range would be outside of the PDP range
         if (virt_addr + (pages * PAGE_SIZE) > (space->pdp_index + 1) * PDP_MEM_RANGE) return false;
 
@@ -384,7 +386,7 @@ bool claim_virt_range(AddressSpace* space, VirtualAddress virt_addr, uint64_t pa
         free_entry->next = (VirtualAddress)space->free_list;
         space->free_list = free_entry;
 
-        space->current_address = virt_addr + pages * PAGE_SIZE;
+        space->current_address = (virt_addr + pages * PAGE_SIZE) & NON_EXT_ADDR_MASK;
     }
     else {
         // TODO(Anton Lilja, 11/05/2021):


### PR DESCRIPTION
This PR contains general improvements and fixes to the paging system.

* Fixed 2 bugs pertaining to sign extending addresses.
* Fixed bug in get_or_alloc_page_entries where the page pool wasn't being filled correctly
* Made sure to zero out allocated page entries and address spaces.
* Made it so extra page entries weren't being allocated through page_table_traversal helper.
* Added function which allows you to change paging flags after they've been set.
* Added more output to page fault handler to aid in debugging.